### PR TITLE
Fix lambda in tgram_docs_bot.py

### DIFF
--- a/examples/tgram_docs_bot.py
+++ b/examples/tgram_docs_bot.py
@@ -15,7 +15,7 @@ all_methods = [
 ]
 
 
-@bot.on_message(filters.Filter(lambda m: m.chat.type == "private") & filters.text)
+@bot.on_message(filters.Filter(lambda _, m: m.chat.type == "private") & filters.text)
 async def on_message(_, m: types.Message):
     return await bot.send_message(
         m.chat.id,


### PR DESCRIPTION
the is error:
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: <lambda>() takes 1 positional argument but 2 were given 
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Inside filters.Filter(lambda m: ...), tgram passes bot and message to the function, but lambda m: ... only expects m, which causes the error. By modifying it to lambda _, m: ..., we show that lambda receives bot as the first parameter and m as the second parameter, and thus it runs without problems.

