### PR TITLE
Update to BotAPI v9.0

### DIFF
--- a/tgram/client/client.py
+++ b/tgram/client/client.py
@@ -15,7 +15,7 @@ from ..errors import APIException
 from ..utils import API_URL, get_file_name, ALL_UPDATES
 from ..sync import wrap, async_to_sync
 from ..storage import KvsqliteStorage, RedisStorage, StorageBase
-from ..types.type_ import Type_
+from ..types.type_ import Type_, Response
 from .dispatcher import Dispatcher
 from concurrent.futures.thread import ThreadPoolExecutor
 
@@ -195,7 +195,7 @@ class TgBot(TelegramBotMethods, Decorators, Dispatcher):
 
         return self._session
 
-    async def __call__(self, method: str, **kwargs) -> Any:
+    async def __call__(self, method: str, **kwargs) -> Response:
         """
         Make an API call to the Telegram Bot API.
 

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -150,6 +150,9 @@ from .chats.remove_user_verification import RemoveUserVerification
 from .payments_and_business.read_business_message import ReadBusinessMessage
 from .payments_and_business.delete_business_messages import DeleteBusinessMessages
 from .payments_and_business.set_business_account_name import SetBusinessAccountName
+from .payments_and_business.set_business_account_username import (
+    SetBusinessAccountUsername,
+)
 
 
 class TelegramBotMethods(
@@ -281,6 +284,7 @@ class TelegramBotMethods(
     SetUserEmojiStatus,
     SetWebhook,
     SetBusinessAccountName,
+    SetBusinessAccountUsername,
     StopMessageLiveLocation,
     StopPoll,
     SavePreparedInlineMessage,

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -175,6 +175,7 @@ from .payments_and_business.upgrade_gift import UpgradeGift
 from .payments_and_business.transfer_gift import TransferGift
 from .payments_and_business.post_story import PostStory
 from .payments_and_business.edit_story import EditStory
+from .payments_and_business.delete_story import DeleteStory
 
 
 class TelegramBotMethods(
@@ -210,6 +211,7 @@ class TelegramBotMethods(
     DeleteStickerFromSet,
     DeleteStickerSet,
     DeleteWebhook,
+    DeleteStory,
     DemoteChatMember,
     DownloadFile,
     EditChatInviteLink,

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -163,6 +163,9 @@ from .payments_and_business.remove_business_account_profile_photo import (
 from .payments_and_business.set_business_account_gift_settings import (
     SetBusinessAccountGiftSettings,
 )
+from .payments_and_business.get_business_account_star_balance import (
+    GetBusinessAccountStarBalance,
+)
 
 
 class TelegramBotMethods(
@@ -236,6 +239,7 @@ class TelegramBotMethods(
     GetUserChatBoosts,
     GetUserProfilePhotos,
     GetWebhookInfo,
+    GetBusinessAccountStarBalance,
     HideGeneralForumTopic,
     LeaveChat,
     LogOut,

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -171,6 +171,7 @@ from .payments_and_business.transfer_business_account_stars import (
 )
 from .payments_and_business.get_business_account_gifts import GetBusinessAccountGifts
 from .payments_and_business.convert_gift_to_stars import ConvertGiftToStars
+from .payments_and_business.upgrade_gift import UpgradeGift
 
 
 class TelegramBotMethods(
@@ -321,6 +322,7 @@ class TelegramBotMethods(
     UnpinChatMessage,
     UnRestrictChatMember,
     UploadStickerFile,
+    UpgradeGift,
     Runner,
     VerifyChat,
     VerifyUser,

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -170,6 +170,7 @@ from .payments_and_business.transfer_business_account_stars import (
     TransferBusinessAccountStars,
 )
 from .payments_and_business.get_business_account_gifts import GetBusinessAccountGifts
+from .payments_and_business.convert_gift_to_stars import ConvertGiftToStars
 
 
 class TelegramBotMethods(
@@ -193,6 +194,7 @@ class TelegramBotMethods(
     CreateForumTopic,
     CreateInvoiceLink,
     CreateNewStickerSet,
+    ConvertGiftToStars,
     DeclineChatJoinRequest,
     DeleteChatPhoto,
     DeleteChatStickerSet,

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -170,6 +170,7 @@ from .payments_and_business.transfer_business_account_stars import (
     TransferBusinessAccountStars,
 )
 from .payments_and_business.get_business_account_gifts import GetBusinessAccountGifts
+from .payments_and_business.gift_premium_subscription import GiftPremiumSubscription
 from .payments_and_business.convert_gift_to_stars import ConvertGiftToStars
 from .payments_and_business.upgrade_gift import UpgradeGift
 from .payments_and_business.transfer_gift import TransferGift
@@ -254,6 +255,7 @@ class TelegramBotMethods(
     GetWebhookInfo,
     GetBusinessAccountGifts,
     GetBusinessAccountStarBalance,
+    GiftPremiumSubscription,
     HideGeneralForumTopic,
     LeaveChat,
     LogOut,

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -174,6 +174,7 @@ from .payments_and_business.convert_gift_to_stars import ConvertGiftToStars
 from .payments_and_business.upgrade_gift import UpgradeGift
 from .payments_and_business.transfer_gift import TransferGift
 from .payments_and_business.post_story import PostStory
+from .payments_and_business.edit_story import EditStory
 
 
 class TelegramBotMethods(
@@ -221,6 +222,7 @@ class TelegramBotMethods(
     EditMessageReplyMarkup,
     EditMessageText,
     EditUserStarSubscription,
+    EditStory,
     ExportChatInviteLink,
     ForwardMessage,
     ForwardMessages,

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -169,6 +169,7 @@ from .payments_and_business.get_business_account_star_balance import (
 from .payments_and_business.transfer_business_account_stars import (
     TransferBusinessAccountStars,
 )
+from .payments_and_business.get_business_account_gifts import GetBusinessAccountGifts
 
 
 class TelegramBotMethods(
@@ -242,6 +243,7 @@ class TelegramBotMethods(
     GetUserChatBoosts,
     GetUserProfilePhotos,
     GetWebhookInfo,
+    GetBusinessAccountGifts,
     GetBusinessAccountStarBalance,
     HideGeneralForumTopic,
     LeaveChat,

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -160,6 +160,9 @@ from .payments_and_business.set_business_account_profile_photo import (
 from .payments_and_business.remove_business_account_profile_photo import (
     RemoveBusinessAccountProfilePhoto,
 )
+from .payments_and_business.set_business_account_gift_settings import (
+    SetBusinessAccountGiftSettings,
+)
 
 
 class TelegramBotMethods(
@@ -294,6 +297,7 @@ class TelegramBotMethods(
     SetBusinessAccountUsername,
     SetBusinessAccountBio,
     SetBusinessAccountProfilePhoto,
+    SetBusinessAccountGiftSettings,
     StopMessageLiveLocation,
     StopPoll,
     SavePreparedInlineMessage,

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -154,6 +154,12 @@ from .payments_and_business.set_business_account_username import (
     SetBusinessAccountUsername,
 )
 from .payments_and_business.set_business_account_bio import SetBusinessAccountBio
+from .payments_and_business.set_business_account_profile_photo import (
+    SetBusinessAccountProfilePhoto,
+)
+from .payments_and_business.remove_business_account_profile_photo import (
+    RemoveBusinessAccountProfilePhoto,
+)
 
 
 class TelegramBotMethods(
@@ -287,6 +293,7 @@ class TelegramBotMethods(
     SetBusinessAccountName,
     SetBusinessAccountUsername,
     SetBusinessAccountBio,
+    SetBusinessAccountProfilePhoto,
     StopMessageLiveLocation,
     StopPoll,
     SavePreparedInlineMessage,
@@ -304,5 +311,6 @@ class TelegramBotMethods(
     VerifyUser,
     RemoveUserVerification,
     RemoveChatVerification,
+    RemoveBusinessAccountProfilePhoto,
 ):
     pass

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -147,6 +147,8 @@ from .chats.verify_user import VerifyUser
 from .chats.remove_chat_verification import RemoveChatVerification
 from .chats.remove_user_verification import RemoveUserVerification
 
+from .payments_and_business.read_business_message import ReadBusinessMessage
+
 
 class TelegramBotMethods(
     AddStickerToSet,
@@ -229,6 +231,7 @@ class TelegramBotMethods(
     ReplaceStickerInSet,
     RestrictChatMember,
     RevokeChatInviteLink,
+    ReadBusinessMessage,
     SendAnimation,
     SendAudio,
     SendChatAction,

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -153,6 +153,7 @@ from .payments_and_business.set_business_account_name import SetBusinessAccountN
 from .payments_and_business.set_business_account_username import (
     SetBusinessAccountUsername,
 )
+from .payments_and_business.set_business_account_bio import SetBusinessAccountBio
 
 
 class TelegramBotMethods(
@@ -285,6 +286,7 @@ class TelegramBotMethods(
     SetWebhook,
     SetBusinessAccountName,
     SetBusinessAccountUsername,
+    SetBusinessAccountBio,
     StopMessageLiveLocation,
     StopPoll,
     SavePreparedInlineMessage,

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -172,6 +172,7 @@ from .payments_and_business.transfer_business_account_stars import (
 from .payments_and_business.get_business_account_gifts import GetBusinessAccountGifts
 from .payments_and_business.convert_gift_to_stars import ConvertGiftToStars
 from .payments_and_business.upgrade_gift import UpgradeGift
+from .payments_and_business.transfer_gift import TransferGift
 
 
 class TelegramBotMethods(
@@ -330,5 +331,6 @@ class TelegramBotMethods(
     RemoveChatVerification,
     RemoveBusinessAccountProfilePhoto,
     TransferBusinessAccountStars,
+    TransferGift,
 ):
     pass

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -173,6 +173,7 @@ from .payments_and_business.get_business_account_gifts import GetBusinessAccount
 from .payments_and_business.convert_gift_to_stars import ConvertGiftToStars
 from .payments_and_business.upgrade_gift import UpgradeGift
 from .payments_and_business.transfer_gift import TransferGift
+from .payments_and_business.post_story import PostStory
 
 
 class TelegramBotMethods(
@@ -332,5 +333,6 @@ class TelegramBotMethods(
     RemoveBusinessAccountProfilePhoto,
     TransferBusinessAccountStars,
     TransferGift,
+    PostStory,
 ):
     pass

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -149,6 +149,7 @@ from .chats.remove_user_verification import RemoveUserVerification
 
 from .payments_and_business.read_business_message import ReadBusinessMessage
 from .payments_and_business.delete_business_messages import DeleteBusinessMessages
+from .payments_and_business.set_business_account_name import SetBusinessAccountName
 
 
 class TelegramBotMethods(
@@ -279,6 +280,7 @@ class TelegramBotMethods(
     SetStickerSetTitle,
     SetUserEmojiStatus,
     SetWebhook,
+    SetBusinessAccountName,
     StopMessageLiveLocation,
     StopPoll,
     SavePreparedInlineMessage,

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -148,6 +148,7 @@ from .chats.remove_chat_verification import RemoveChatVerification
 from .chats.remove_user_verification import RemoveUserVerification
 
 from .payments_and_business.read_business_message import ReadBusinessMessage
+from .payments_and_business.delete_business_messages import DeleteBusinessMessages
 
 
 class TelegramBotMethods(
@@ -177,6 +178,7 @@ class TelegramBotMethods(
     DeleteForumTopic,
     DeleteMessage,
     DeleteMessages,
+    DeleteBusinessMessages,
     DeleteMyCommands,
     DeleteStickerFromSet,
     DeleteStickerSet,

--- a/tgram/methods/__init__.py
+++ b/tgram/methods/__init__.py
@@ -166,6 +166,9 @@ from .payments_and_business.set_business_account_gift_settings import (
 from .payments_and_business.get_business_account_star_balance import (
     GetBusinessAccountStarBalance,
 )
+from .payments_and_business.transfer_business_account_stars import (
+    TransferBusinessAccountStars,
+)
 
 
 class TelegramBotMethods(
@@ -320,5 +323,6 @@ class TelegramBotMethods(
     RemoveUserVerification,
     RemoveChatVerification,
     RemoveBusinessAccountProfilePhoto,
+    TransferBusinessAccountStars,
 ):
     pass

--- a/tgram/methods/payments_and_business/convert_gift_to_stars.py
+++ b/tgram/methods/payments_and_business/convert_gift_to_stars.py
@@ -1,0 +1,22 @@
+import tgram
+
+
+class ConvertGiftToStars:
+    async def convert_gift_to_stars(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        owned_gift_id: str,
+    ) -> bool:
+        """
+        Converts a given regular gift to Telegram Stars. Requires the can_convert_gifts_to_stars business bot right. Returns True on success.
+
+        Parameters:
+            business_connection_id (str): Unique identifier of the business connection.
+            owned_gift_id (str): Unique identifier of the regular gift that should be converted to Telegram Stars.
+        """
+        result = await self(
+            "convertGiftToStars",
+            business_connection_id=business_connection_id,
+            owned_gift_id=owned_gift_id,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/delete_business_messages.py
+++ b/tgram/methods/payments_and_business/delete_business_messages.py
@@ -1,0 +1,33 @@
+import tgram
+from typing import List
+
+
+class DeleteBusinessMessages:
+    async def delete_business_messages(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        message_ids: List[int],
+    ) -> bool:
+        """
+        Deletes messages on behalf of a business account.
+        Requires the can_delete_sent_messages business bot right to delete messages sent by the bot itself,
+        or the can_delete_all_messages business bot right to delete any message.
+
+        Telegram documentation: https://core.telegram.org/bots/api#deletebusinessmessages
+
+        :param business_connection_id: Unique identifier of the business connection on behalf of which to delete the messages
+        :type business_connection_id: :obj:`str`
+
+        :param message_ids: A JSON-serialized list of 1-100 identifiers of messages to delete. All messages must be from the same chat.
+        :type message_ids: :obj:`list[int]`
+
+        :return: On success, returns True.
+        :rtype: :obj:`bool`
+        """
+
+        result = await self(
+            "deleteBusinessMessages",
+            business_connection_id=business_connection_id,
+            message_ids=message_ids,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/delete_story.py
+++ b/tgram/methods/payments_and_business/delete_story.py
@@ -1,0 +1,30 @@
+import tgram
+
+
+class DeleteStory:
+    async def delete_story(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        story_id: int,
+    ) -> bool:
+        """
+        Deletes a story previously posted by the bot on behalf of a managed business account.
+        Requires the can_manage_stories business bot right.
+
+        Telegram documentation: https://core.telegram.org/bots/api#deletestory
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param story_id: Unique identifier of the story to delete
+        :type story_id: :obj:`int`
+
+        :return: True on success.
+        :rtype: :obj:`bool`
+        """
+        result = await self(
+            "deleteStory",
+            business_connection_id=business_connection_id,
+            story_id=story_id,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/edit_story.py
+++ b/tgram/methods/payments_and_business/edit_story.py
@@ -1,0 +1,57 @@
+import tgram
+
+from typing import List
+
+
+class EditStory:
+    async def edit_story(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        story_id: int,
+        content: "tgram.types.InputStoryContent",
+        caption: str = None,
+        parse_mode: str = None,
+        caption_entities: List["tgram.types.MessageEntity"] = None,
+        areas: List["tgram.types.StoryArea"] = None,
+    ) -> "tgram.types.Story":
+        """
+        Edits a story previously posted by the bot on behalf of a managed business account.
+        Requires the can_manage_stories business bot right.
+
+        Telegram documentation: https://core.telegram.org/bots/api#editstory
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param story_id: Unique identifier of the story to edit
+        :type story_id: :obj:`int`
+
+        :param content: Content of the story
+        :type content: :class:`tgram.types.InputStoryContent`
+
+        :param caption: Caption of the story, 0-2048 characters after entities parsing
+        :type caption: :obj:`str`, optional
+
+        :param parse_mode: Mode for parsing entities in the story caption
+        :type parse_mode: :obj:`str`, optional
+
+        :param caption_entities: A JSON-serialized list of special entities that appear in the caption
+        :type caption_entities: :obj:`list`, optional
+
+        :param areas: A JSON-serialized list of clickable areas to be shown on the story
+        :type areas: :obj:`list`, optional
+
+        :return: On success, returns a Story object.
+        :rtype: :class:`tgram.types.Story`
+        """
+        result = await self(
+            "editStory",
+            business_connection_id=business_connection_id,
+            story_id=story_id,
+            content=content,
+            caption=caption,
+            parse_mode=parse_mode,
+            caption_entities=caption_entities,
+            areas=areas,
+        )
+        return tgram.types.Story._parse(me=self, d=result["result"])

--- a/tgram/methods/payments_and_business/get_business_account_gifts.py
+++ b/tgram/methods/payments_and_business/get_business_account_gifts.py
@@ -1,0 +1,59 @@
+import tgram
+from tgram.types import OwnedGifts
+
+
+class GetBusinessAccountGifts:
+    async def get_business_account_gifts(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        exclude_unsaved: bool = None,
+        exclude_saved: bool = None,
+        exclude_unlimited: bool = None,
+        exclude_limited: bool = None,
+        exclude_unique: bool = None,
+        sort_by_price: bool = None,
+        offset: str = "",
+        limit: int = 100,
+    ) -> OwnedGifts:
+        """
+        Use this method to get the gifts received and owned by a managed business account.
+        Requires the can_view_gifts_and_stars business bot right.
+        Returns an OwnedGifts object on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#getbusinessaccountgifts
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+        :param exclude_unsaved: Exclude gifts that aren't saved to the account's profile page
+        :type exclude_unsaved: :obj:`bool`, optional
+        :param exclude_saved: Exclude gifts that are saved to the account's profile page
+        :type exclude_saved: :obj:`bool`, optional
+        :param exclude_unlimited: Exclude gifts that can be purchased an unlimited number of times
+        :type exclude_unlimited: :obj:`bool`, optional
+        :param exclude_limited: Exclude gifts that can be purchased a limited number of times
+        :type exclude_limited: :obj:`bool`, optional
+        :param exclude_unique: Exclude unique gifts
+        :type exclude_unique: :obj:`bool`, optional
+        :param sort_by_price: Sort results by gift price instead of send date
+        :type sort_by_price: :obj:`bool`, optional
+        :param offset: Offset of the first entry to return; use empty string for first chunk
+        :type offset: :obj:`str`, optional
+        :param limit: Maximum number of gifts to return; 1-100, defaults to 100
+        :type limit: :obj:`int`, optional
+
+        :return: Returns an OwnedGifts object on success.
+        :rtype: :class:`tgram.types.OwnedGifts`
+        """
+        result = await self(
+            "getBusinessAccountGifts",
+            business_connection_id=business_connection_id,
+            exclude_unsaved=exclude_unsaved,
+            exclude_saved=exclude_saved,
+            exclude_unlimited=exclude_unlimited,
+            exclude_limited=exclude_limited,
+            exclude_unique=exclude_unique,
+            sort_by_price=sort_by_price,
+            offset=offset,
+            limit=limit,
+        )
+        return OwnedGifts._parse(me=self, d=result["result"])

--- a/tgram/methods/payments_and_business/get_business_account_star_balance.py
+++ b/tgram/methods/payments_and_business/get_business_account_star_balance.py
@@ -1,0 +1,21 @@
+import tgram
+from tgram.types import StarAmount
+
+
+class GetBusinessAccountStarBalance:
+    async def get_business_account_star_balance(
+        self: "tgram.TgBot", business_connection_id: str
+    ) -> StarAmount:
+        """
+        Returns the amount of Telegram Stars owned by a managed business account.
+
+        Telegram documentation: https://core.telegram.org/bots/api#getbusinessaccountstarbalance
+
+        :param business_connection_id: Unique identifier of the business connection
+        :return: StarAmount object
+        """
+        result = await self(
+            "getBusinessAccountStarBalance",
+            business_connection_id=business_connection_id,
+        )
+        return StarAmount._parse(me=self, d=result["result"])

--- a/tgram/methods/payments_and_business/gift_premium_subscription.py
+++ b/tgram/methods/payments_and_business/gift_premium_subscription.py
@@ -1,0 +1,52 @@
+import tgram
+
+from typing import List
+
+
+class GiftPremiumSubscription:
+    async def gift_premium_subscription(
+        self: "tgram.TgBot",
+        user_id: int,
+        month_count: int,
+        star_count: int,
+        text: str = None,
+        text_parse_mode: str = None,
+        text_entities: List["tgram.types.MessageEntity"] = None,
+    ) -> bool:
+        """
+        Gifts a Telegram Premium subscription to the given user.
+        Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#giftpremiumsubscription
+
+        :param user_id: Unique identifier of the target user who will receive a Telegram Premium subscription
+        :type user_id: :obj:`int`
+
+        :param month_count: Number of months the Telegram Premium subscription will be active for the user; must be one of 3, 6, or 12
+        :type month_count: :obj:`int`
+
+        :param star_count: Number of Telegram Stars to pay for the Telegram Premium subscription; must be 1000 for 3 months, 1500 for 6 months, and 2500 for 12 months
+        :type star_count: :obj:`int`
+
+        :param text: Text that will be shown along with the service message about the subscription; 0-128 characters
+        :type text: :obj:`str`, optional
+
+        :param text_parse_mode: Mode for parsing entities in the text
+        :type text_parse_mode: :obj:`str`, optional
+
+        :param text_entities: A JSON-serialized list of special entities that appear in the gift text
+        :type text_entities: :obj:`list`, optional
+
+        :return: True on success.
+        :rtype: :obj:`bool`
+        """
+        result = await self(
+            "giftPremiumSubscription",
+            user_id=user_id,
+            month_count=month_count,
+            star_count=star_count,
+            text=text,
+            text_parse_mode=text_parse_mode,
+            text_entities=text_entities,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/post_story.py
+++ b/tgram/methods/payments_and_business/post_story.py
@@ -1,0 +1,67 @@
+import tgram
+
+from typing import List
+
+
+class PostStory:
+    async def post_story(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        content: "tgram.types.InputStoryContent",
+        active_period: int,
+        caption: str = None,
+        parse_mode: str = None,
+        caption_entities: List["tgram.types.MessageEntity"] = None,
+        areas: List["tgram.types.StoryArea"] = None,
+        post_to_chat_page: bool = None,
+        protect_content: bool = None,
+    ) -> "tgram.types.Story":
+        """
+        Posts a story on behalf of a managed business account.
+        Requires the can_manage_stories business bot right.
+
+        Telegram documentation: https://core.telegram.org/bots/api#poststory
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param content: Content of the story
+        :type content: :class:`tgram.types.InputStoryContent`
+
+        :param active_period: Period after which the story is moved to the archive, in seconds; must be one of 6 * 3600, 12 * 3600, 86400, or 2 * 86400
+        :type active_period: :obj:`int`
+
+        :param caption: Caption of the story, 0-2048 characters after entities parsing
+        :type caption: :obj:`str`, optional
+
+        :param parse_mode: Mode for parsing entities in the story caption
+        :type parse_mode: :obj:`str`, optional
+
+        :param caption_entities: A JSON-serialized list of special entities that appear in the caption
+        :type caption_entities: :obj:`list`, optional
+
+        :param areas: A JSON-serialized list of clickable areas to be shown on the story
+        :type areas: :obj:`list`, optional
+
+        :param post_to_chat_page: Pass True to keep the story accessible after it expires
+        :type post_to_chat_page: :obj:`bool`, optional
+
+        :param protect_content: Pass True if the content of the story must be protected from forwarding and screenshotting
+        :type protect_content: :obj:`bool`, optional
+
+        :return: On success, returns a Story object.
+        :rtype: :class:`tgram.types.Story`
+        """
+        result = await self(
+            "postStory",
+            business_connection_id=business_connection_id,
+            content=content,
+            active_period=active_period,
+            caption=caption,
+            parse_mode=parse_mode,
+            caption_entities=caption_entities,
+            areas=areas,
+            post_to_chat_page=post_to_chat_page,
+            protect_content=protect_content,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/post_story.py
+++ b/tgram/methods/payments_and_business/post_story.py
@@ -64,4 +64,4 @@ class PostStory:
             post_to_chat_page=post_to_chat_page,
             protect_content=protect_content,
         )
-        return result["result"]
+        return tgram.types.Story._parse(me=self, d=result["result"])

--- a/tgram/methods/payments_and_business/read_business_message.py
+++ b/tgram/methods/payments_and_business/read_business_message.py
@@ -1,0 +1,36 @@
+import tgram
+
+
+class ReadBusinessMessage:
+    async def read_business_message(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        chat_id: int,
+        message_id: int,
+    ) -> bool:
+        """
+        Marks an incoming message as read on behalf of a business account.
+        Requires the can_read_messages business bot right.
+
+        Telegram documentation: https://core.telegram.org/bots/api#readbusinessmessage
+
+        :param business_connection_id: Unique identifier of the business connection on behalf of which to read the message
+        :type business_connection_id: :obj:`str`
+
+        :param chat_id: Unique identifier of the chat in which the message was received. The chat must have been active in the last 24 hours.
+        :type chat_id: :obj:`int`
+
+        :param message_id: Unique identifier of the message to mark as read
+        :type message_id: :obj:`int`
+
+        :return: On success, returns True.
+        :rtype: :obj:`bool`
+        """
+
+        result = await self(
+            "readBusinessMessage",
+            business_connection_id=business_connection_id,
+            chat_id=chat_id,
+            message_id=message_id,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/remove_business_account_profile_photo.py
+++ b/tgram/methods/payments_and_business/remove_business_account_profile_photo.py
@@ -1,0 +1,30 @@
+import tgram
+
+
+class RemoveBusinessAccountProfilePhoto:
+    async def remove_business_account_profile_photo(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        is_public: bool = None,
+    ) -> bool:
+        """
+        Removes the current profile photo of a managed business account.
+        Requires the can_edit_profile_photo business bot right.
+
+        Telegram documentation: https://core.telegram.org/bots/api#removebusinessaccountprofilephoto
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param is_public: Pass True to remove the public photo, which is visible even if the main photo is hidden by the business account's privacy settings. After the main photo is removed, the previous profile photo (if present) becomes the main photo.
+        :type is_public: :obj:`bool`, optional
+
+        :return: On success, returns True.
+        :rtype: :obj:`bool`
+        """
+        result = await self(
+            "removeBusinessAccountProfilePhoto",
+            business_connection_id=business_connection_id,
+            is_public=is_public,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/set_business_account_bio.py
+++ b/tgram/methods/payments_and_business/set_business_account_bio.py
@@ -1,0 +1,31 @@
+import tgram
+
+
+class SetBusinessAccountBio:
+    async def set_business_account_bio(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        bio: str = None,
+    ) -> bool:
+        """
+        Changes the bio of a managed business account.
+        Requires the can_change_bio business bot right.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountbio
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param bio: The new value of the bio for the business account; 0-140 characters
+        :type bio: :obj:`str`, optional
+
+        :return: On success, returns True.
+        :rtype: :obj:`bool`
+        """
+
+        result = await self(
+            "setBusinessAccountBio",
+            business_connection_id=business_connection_id,
+            bio=bio,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/set_business_account_gift_settings.py
+++ b/tgram/methods/payments_and_business/set_business_account_gift_settings.py
@@ -1,0 +1,35 @@
+import tgram
+
+
+class SetBusinessAccountGiftSettings:
+    async def set_business_account_gift_settings(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        show_gift_button: bool,
+        accepted_gift_types: "tgram.types.AcceptedGiftTypes",
+    ) -> bool:
+        """
+        Changes the privacy settings pertaining to incoming gifts in a managed business account.
+        Requires the can_change_gift_settings business bot right.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountgiftsettings
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param show_gift_button: Pass True, if a button for sending a gift to the user or by the business account must always be shown in the input field
+        :type show_gift_button: :obj:`bool`
+
+        :param accepted_gift_types: Types of gifts accepted by the business account
+        :type accepted_gift_types: :obj:`tgram.types.AcceptedGiftTypes`
+
+        :return: On success, returns True.
+        :rtype: :obj:`bool`
+        """
+        result = await self(
+            "setBusinessAccountGiftSettings",
+            business_connection_id=business_connection_id,
+            show_gift_button=show_gift_button,
+            accepted_gift_types=accepted_gift_types,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/set_business_account_name.py
+++ b/tgram/methods/payments_and_business/set_business_account_name.py
@@ -1,0 +1,36 @@
+import tgram
+
+
+class SetBusinessAccountName:
+    async def set_business_account_name(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        first_name: str,
+        last_name: str = None,
+    ) -> bool:
+        """
+        Changes the first and last name of a managed business account.
+        Requires the can_change_name business bot right.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountname
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param first_name: The new value of the first name for the business account; 1-64 characters
+        :type first_name: :obj:`str`
+
+        :param last_name: The new value of the last name for the business account; 0-64 characters
+        :type last_name: :obj:`str`, optional
+
+        :return: On success, returns True.
+        :rtype: :obj:`bool`
+        """
+
+        result = await self(
+            "setBusinessAccountName",
+            business_connection_id=business_connection_id,
+            first_name=first_name,
+            last_name=last_name,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/set_business_account_profile_photo.py
+++ b/tgram/methods/payments_and_business/set_business_account_profile_photo.py
@@ -1,0 +1,43 @@
+import tgram
+
+from typing import Union
+from tgram.utils import convert_input_media
+
+
+class SetBusinessAccountProfilePhoto:
+    async def set_business_account_profile_photo(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        photo: Union[
+            "tgram.types.InputProfilePhotoStatic",
+            "tgram.types.InputProfilePhotoAnimated",
+        ],
+        is_public: bool = None,
+    ) -> bool:
+        """
+        Changes the profile photo of a managed business account.
+        Requires the can_edit_profile_photo business bot right.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountprofilephoto
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param photo: The new profile photo to set
+        :type photo: :class:`tgram.types.InputProfilePhotoStatic` or :class:`tgram.types.InputProfilePhotoAnimated`
+
+        :param is_public: Pass True to set the public photo, which will be visible even if the main photo is hidden by the business account's privacy settings. An account can have only one public photo.
+        :type is_public: :obj:`bool`, optional
+
+        :return: On success, returns True.
+        :rtype: :obj:`bool`
+        """
+        converted, file = convert_input_media([photo])
+        result = await self(
+            "setBusinessAccountProfilePhoto",
+            business_connection_id=business_connection_id,
+            photo=converted[0],
+            is_public=is_public,
+            **file,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/set_business_account_username.py
+++ b/tgram/methods/payments_and_business/set_business_account_username.py
@@ -1,0 +1,30 @@
+import tgram
+
+class SetBusinessAccountUsername:
+    async def set_business_account_username(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        username: str = None,
+    ) -> bool:
+        """
+        Changes the username of a managed business account.
+        Requires the can_change_username business bot right.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountusername
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param username: The new value of the username for the business account; 0-32 characters
+        :type username: :obj:`str`, optional
+
+        :return: On success, returns True.
+        :rtype: :obj:`bool`
+        """
+
+        result = await self(
+            "setBusinessAccountUsername",
+            business_connection_id=business_connection_id,
+            username=username,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/set_business_account_username.py
+++ b/tgram/methods/payments_and_business/set_business_account_username.py
@@ -1,5 +1,6 @@
 import tgram
 
+
 class SetBusinessAccountUsername:
     async def set_business_account_username(
         self: "tgram.TgBot",

--- a/tgram/methods/payments_and_business/transfer_business_account_stars.py
+++ b/tgram/methods/payments_and_business/transfer_business_account_stars.py
@@ -1,0 +1,35 @@
+import tgram
+
+
+class TransferBusinessAccountStars:
+    async def transfer_business_account_stars(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        star_count: int,
+    ) -> bool:
+        """
+        Transfers Telegram Stars from the business account balance to the bot's balance.
+        Requires the can_transfer_stars business bot right.
+
+        Telegram documentation: https://core.telegram.org/bots/api#transferbusinessaccountstars
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param star_count: Number of Telegram Stars to transfer; 1-10000
+        :type star_count: :obj:`int`
+
+        :return: On success, returns True.
+        :rtype: :obj:`bool`
+
+        :raises ValueError: If star_count is not in the range 1-10000.
+        """
+        if not (1 <= star_count <= 10000):
+            raise ValueError("star_count must be between 1 and 10000")
+
+        result = await self(
+            "transferBusinessAccountStars",
+            business_connection_id=business_connection_id,
+            star_count=star_count,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/transfer_gift.py
+++ b/tgram/methods/payments_and_business/transfer_gift.py
@@ -1,0 +1,29 @@
+import tgram
+
+
+class TransferGift:
+    async def transfer_gift(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        owned_gift_id: str,
+        new_owner_chat_id: int,
+        star_count: int = None,
+    ) -> bool:
+        """
+        Transfers an owned unique gift to another user. Requires the can_transfer_and_upgrade_gifts business bot right.
+        Requires can_transfer_stars business bot right if the transfer is paid. Returns True on success.
+
+        Parameters:
+            business_connection_id (str): Unique identifier of the business connection.
+            owned_gift_id (str): Unique identifier of the regular gift that should be transferred.
+            new_owner_chat_id (int): Unique identifier of the chat which will own the gift. The chat must be active in the last 24 hours.
+            star_count (int, optional): The amount of Telegram Stars that will be paid for the transfer from the business account balance. If positive, then the can_transfer_stars business bot right is required.
+        """
+        result = await self(
+            "transferGift",
+            business_connection_id=business_connection_id,
+            owned_gift_id=owned_gift_id,
+            new_owner_chat_id=new_owner_chat_id,
+            star_count=star_count,
+        )
+        return result["result"]

--- a/tgram/methods/payments_and_business/upgrade_gift.py
+++ b/tgram/methods/payments_and_business/upgrade_gift.py
@@ -1,0 +1,29 @@
+import tgram
+
+
+class UpgradeGift:
+    async def upgrade_gift(
+        self: "tgram.TgBot",
+        business_connection_id: str,
+        owned_gift_id: str,
+        keep_original_details: bool = None,
+        star_count: int = None,
+    ) -> bool:
+        """
+        Upgrades a given regular gift to a unique gift. Requires the can_transfer_and_upgrade_gifts business bot right.
+        Additionally requires the can_transfer_stars business bot right if the upgrade is paid. Returns True on success.
+
+        Parameters:
+            business_connection_id (str): Unique identifier of the business connection.
+            owned_gift_id (str): Unique identifier of the regular gift that should be upgraded to a unique one.
+            keep_original_details (bool, optional): Pass True to keep the original gift text, sender and receiver in the upgraded gift.
+            star_count (int, optional): The amount of Telegram Stars that will be paid for the upgrade from the business account balance.
+        """
+        result = await self(
+            "upgradeGift",
+            business_connection_id=business_connection_id,
+            owned_gift_id=owned_gift_id,
+            keep_original_details=keep_original_details,
+            star_count=star_count,
+        )
+        return result["result"]

--- a/tgram/types/__init__.py
+++ b/tgram/types/__init__.py
@@ -187,6 +187,7 @@ from ._poll_option import PollOption
 from ._pre_checkout_query import PreCheckoutQuery
 from ._prepared_inline_message import PreparedInlineMessage
 from ._proximity_alert_triggered import ProximityAlertTriggered
+from ._paid_message_price_changed import PaidMessagePriceChanged
 from ._reaction_count import ReactionCount
 from ._reaction_type_custom_emoji import ReactionTypeCustomEmoji
 from ._reaction_type_emoji import ReactionTypeEmoji
@@ -615,4 +616,5 @@ __all__ = [
     "OwnedGiftRegular",
     "OwnedGiftUnique",
     "LocationAddress",
+    "PaidMessagePriceChanged",
 ]

--- a/tgram/types/__init__.py
+++ b/tgram/types/__init__.py
@@ -231,6 +231,7 @@ from ._unique_gifts import (
     UniqueGiftModel,
     UniqueGiftSymbol,
 )
+from ._owned_gifts import OwnedGifts, OwnedGiftRegular, OwnedGiftUnique
 from ._venue import Venue
 from ._video import Video
 from ._video_chat_ended import VideoChatEnded
@@ -578,4 +579,7 @@ __all__ = [
     "PreparedInlineMessage",
     "Gift",
     "Gifts",
+    "OwnedGifts",
+    "OwnedGiftRegular",
+    "OwnedGiftUnique",
 ]

--- a/tgram/types/__init__.py
+++ b/tgram/types/__init__.py
@@ -84,6 +84,7 @@ from ._general_forum_topic_hidden import GeneralForumTopicHidden
 from ._general_forum_topic_unhidden import GeneralForumTopicUnhidden
 from ._gifts import Gifts
 from ._gift import Gift
+from ._gift_info import GiftInfo
 from ._giveaway import Giveaway
 from ._giveaway_completed import GiveawayCompleted
 from ._giveaway_created import GiveawayCreated
@@ -220,6 +221,14 @@ from ._user import User
 from ._user_chat_boosts import UserChatBoosts
 from ._user_profile_photos import UserProfilePhotos
 from ._users_shared import UsersShared
+from ._unique_gifts import (
+    UniqueGift,
+    UniqueGiftBackdrop,
+    UniqueGiftBackdropColors,
+    UniqueGiftInfo,
+    UniqueGiftModel,
+    UniqueGiftSymbol,
+)
 from ._venue import Venue
 from ._video import Video
 from ._video_chat_ended import VideoChatEnded
@@ -404,6 +413,7 @@ __all__ = [
     "GiveawayCompleted",
     "GiveawayCreated",
     "GiveawayWinners",
+    "GiftInfo",
     "InaccessibleMessage",
     "InlineKeyboardButton",
     "InlineKeyboardMarkup",
@@ -540,6 +550,12 @@ __all__ = [
     "UserChatBoosts",
     "UserProfilePhotos",
     "UsersShared",
+    "UniqueGift",
+    "UniqueGiftBackdrop",
+    "UniqueGiftBackdropColors",
+    "UniqueGiftInfo",
+    "UniqueGiftModel",
+    "UniqueGiftSymbol",
     "Venue",
     "Video",
     "VideoChatEnded",

--- a/tgram/types/__init__.py
+++ b/tgram/types/__init__.py
@@ -15,6 +15,7 @@ from ._background_type_fill import BackgroundTypeFill
 from ._background_type_pattern import BackgroundTypePattern
 from ._background_type_wallpaper import BackgroundTypeWallpaper
 from ._birthdate import Birthdate
+from ._business_bot_rights import BusinessBotRights
 from ._bot_command import BotCommand
 from ._bot_command_scope import BotCommandScope
 from ._bot_command_scope_all_chat_administrators import (
@@ -334,6 +335,7 @@ __all__ = [
     "BackgroundTypePattern",
     "BackgroundTypeWallpaper",
     "Birthdate",
+    "BusinessBotRights",
     "BotCommand",
     "BotCommandScope",
     "BotCommandScopeAllChatAdministrators",

--- a/tgram/types/__init__.py
+++ b/tgram/types/__init__.py
@@ -142,6 +142,7 @@ from ._link_preview_options import LinkPreviewOptions
 from ._listener import Listener
 from ._location import Location
 from ._login_url import LoginUrl
+from ._location_address import LocationAddress
 from ._mask_position import MaskPosition
 from ._menu_button import MenuButton
 from ._menu_button_commands import MenuButtonCommands
@@ -209,6 +210,15 @@ from ._star_amount import StarAmount
 from ._sticker import Sticker
 from ._sticker_set import StickerSet
 from ._story import Story
+from ._story_area import (
+    StoryArea,
+    StoryAreaPosition,
+    StoryAreaTypeLink,
+    StoryAreaTypeLocation,
+    StoryAreaTypeSuggestedReaction,
+    StoryAreaTypeUniqueGift,
+    StoryAreaTypeWeather,
+)
 from ._successful_payment import SuccessfulPayment
 from ._switch_inline_query_chosen_chat import SwitchInlineQueryChosenChat
 from ._text_quote import TextQuote
@@ -335,6 +345,14 @@ MessageEntityType = _Literal[
 ]
 
 InputStoryContent = _Union["InputStoryContentPhoto", "InputStoryContentVideo"]
+
+StoryAreaType = _Union[
+    "StoryAreaTypeLink",
+    "StoryAreaTypeLocation",
+    "StoryAreaTypeSuggestedReaction",
+    "StoryAreaTypeUniqueGift",
+    "StoryAreaTypeWeather",
+]
 
 __all__ = [
     "AcceptedGiftTypes",
@@ -545,8 +563,16 @@ __all__ = [
     "StarAmount",
     "Sticker",
     "StickerSet",
-    "Story",
     "SuccessfulPayment",
+    "Story",
+    "StoryArea",
+    "StoryAreaPosition",
+    "StoryAreaTypeLink",
+    "StoryAreaTypeLocation",
+    "StoryAreaTypeSuggestedReaction",
+    "StoryAreaTypeUniqueGift",
+    "StoryAreaTypeWeather",
+    "StoryAreaTypeSuccessfulPayment",
     "SwitchInlineQueryChosenChat",
     "TextQuote",
     "TransactionPartnerAffiliateProgram",
@@ -588,4 +614,5 @@ __all__ = [
     "OwnedGifts",
     "OwnedGiftRegular",
     "OwnedGiftUnique",
+    "LocationAddress",
 ]

--- a/tgram/types/__init__.py
+++ b/tgram/types/__init__.py
@@ -204,6 +204,7 @@ from ._shipping_option import ShippingOption
 from ._shipping_query import ShippingQuery
 from ._star_transaction import StarTransaction
 from ._star_transactions import StarTransactions
+from ._star_amount import StarAmount
 from ._sticker import Sticker
 from ._sticker_set import StickerSet
 from ._story import Story
@@ -534,6 +535,7 @@ __all__ = [
     "ShippingQuery",
     "StarTransaction",
     "StarTransactions",
+    "StarAmount",
     "Sticker",
     "StickerSet",
     "Story",

--- a/tgram/types/__init__.py
+++ b/tgram/types/__init__.py
@@ -573,7 +573,7 @@ __all__ = [
     "StoryAreaTypeSuggestedReaction",
     "StoryAreaTypeUniqueGift",
     "StoryAreaTypeWeather",
-    "StoryAreaTypeSuccessfulPayment",
+    "StoryAreaType",
     "SwitchInlineQueryChosenChat",
     "TextQuote",
     "TransactionPartnerAffiliateProgram",

--- a/tgram/types/__init__.py
+++ b/tgram/types/__init__.py
@@ -131,6 +131,7 @@ from ._input_poll_option import InputPollOption
 from ._input_sticker import InputSticker
 from ._input_text_message_content import InputTextMessageContent
 from ._input_venue_message_content import InputVenueMessageContent
+from ._input_story_content import InputStoryContentPhoto, InputStoryContentVideo
 from ._invoice import Invoice
 from ._keyboard_button import KeyboardButton
 from ._keyboard_button_poll_type import KeyboardButtonPollType
@@ -333,6 +334,8 @@ MessageEntityType = _Literal[
     "custom_emoji",
 ]
 
+InputStoryContent = _Union["InputStoryContentPhoto", "InputStoryContentVideo"]
+
 __all__ = [
     "AcceptedGiftTypes",
     "AffiliateInfo",
@@ -462,6 +465,9 @@ __all__ = [
     "InputProfilePhotoAnimated",
     "InputPollOption",
     "InputSticker",
+    "InputStoryContentPhoto",
+    "InputStoryContentVideo",
+    "InputStoryContent",
     "InputTextMessageContent",
     "InputVenueMessageContent",
     "Invoice",

--- a/tgram/types/__init__.py
+++ b/tgram/types/__init__.py
@@ -15,7 +15,6 @@ from ._background_type_fill import BackgroundTypeFill
 from ._background_type_pattern import BackgroundTypePattern
 from ._background_type_wallpaper import BackgroundTypeWallpaper
 from ._birthdate import Birthdate
-from ._business_bot_rights import BusinessBotRights
 from ._bot_command import BotCommand
 from ._bot_command_scope import BotCommandScope
 from ._bot_command_scope_all_chat_administrators import (
@@ -125,6 +124,7 @@ from ._input_media_video import InputMediaVideo
 from ._input_message_content import InputMessageContent
 from ._input_paid_media_photo import InputPaidMediaPhoto
 from ._input_paid_media_video import InputPaidMediaVideo
+from ._input_profile_photo import InputProfilePhotoStatic, InputProfilePhotoAnimated
 from ._input_poll_option import InputPollOption
 from ._input_sticker import InputSticker
 from ._input_text_message_content import InputTextMessageContent
@@ -335,7 +335,6 @@ __all__ = [
     "BackgroundTypePattern",
     "BackgroundTypeWallpaper",
     "Birthdate",
-    "BusinessBotRights",
     "BotCommand",
     "BotCommandScope",
     "BotCommandScopeAllChatAdministrators",
@@ -445,6 +444,8 @@ __all__ = [
     "InputPaidMedia",
     "InputPaidMediaPhoto",
     "InputPaidMediaVideo",
+    "InputProfilePhotoStatic",
+    "InputProfilePhotoAnimated",
     "InputPollOption",
     "InputSticker",
     "InputTextMessageContent",

--- a/tgram/types/__init__.py
+++ b/tgram/types/__init__.py
@@ -2,6 +2,7 @@ from pathlib import Path as _Path
 from typing import Union as _Union, Literal as _Literal
 from io import BytesIO as _BytesIo
 
+from ._accepted_gift_types import AcceptedGiftTypes
 from ._affiliate_info import AffiliateInfo
 from ._animation import Animation
 from ._audio import Audio
@@ -331,6 +332,7 @@ MessageEntityType = _Literal[
 ]
 
 __all__ = [
+    "AcceptedGiftTypes",
     "AffiliateInfo",
     "Animation",
     "Audio",

--- a/tgram/types/_accepted_gift_types.py
+++ b/tgram/types/_accepted_gift_types.py
@@ -1,0 +1,63 @@
+import tgram
+from .type_ import Type_
+from typing import Optional
+
+
+class AcceptedGiftTypes(Type_):
+    """
+    This object describes the types of gifts that can be gifted to a user or a chat.
+
+    Telegram Documentation: https://core.telegram.org/bots/api#acceptedgifttypes
+
+    :param unlimited_gifts: True, if unlimited regular gifts are accepted
+    :type unlimited_gifts: :obj:`bool`
+
+    :param limited_gifts: True, if limited regular gifts are accepted
+    :type limited_gifts: :obj:`bool`
+
+    :param unique_gifts: True, if unique gifts or gifts that can be upgraded to unique for free are accepted
+    :type unique_gifts: :obj:`bool`
+
+    :param premium_subscription: True, if a Telegram Premium subscription is accepted
+    :type premium_subscription: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`tgram.types.AcceptedGiftTypes`
+    """
+
+    def __init__(
+        self,
+        unlimited_gifts: bool = None,
+        limited_gifts: bool = None,
+        unique_gifts: bool = None,
+        premium_subscription: bool = None,
+        me: "tgram.TgBot" = None,
+        json: "dict" = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.unlimited_gifts = unlimited_gifts
+        self.limited_gifts = limited_gifts
+        self.unique_gifts = unique_gifts
+        self.premium_subscription = premium_subscription
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["tgram.types.AcceptedGiftTypes"]:
+        return (
+            AcceptedGiftTypes(
+                me=me,
+                json=d,
+                unlimited_gifts=d.get("unlimited_gifts"),
+                limited_gifts=d.get("limited_gifts"),
+                unique_gifts=d.get("unique_gifts"),
+                premium_subscription=d.get("premium_subscription"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )

--- a/tgram/types/_business_bot_rights.py
+++ b/tgram/types/_business_bot_rights.py
@@ -1,0 +1,112 @@
+import tgram
+from .type_ import Type_
+
+from typing import Optional
+
+
+class BusinessBotRights(Type_):
+    """
+
+    Represents the rights of a business bot.
+
+    Telegram Documentation: https://core.telegram.org/bots/api#businessbotrights
+
+    :param can_reply: Optional. True, if the bot can send and edit messages in the private chats that had incoming messages in the last 24 hours.
+    :type can_reply: bool, optional
+    :param can_read_messages: Optional. True, if the bot can mark incoming private messages as read.
+    :type can_read_messages: bool, optional
+    :param can_delete_sent_messages: Optional. True, if the bot can delete messages sent by the bot.
+    :type can_delete_sent_messages: bool, optional
+    :param can_delete_all_messages: Optional. True, if the bot can delete all private messages in managed chats.
+    :type can_delete_all_messages: bool, optional
+    :param can_edit_name: Optional. True, if the bot can edit the first and last name of the business account.
+    :type can_edit_name: bool, optional
+    :param can_edit_bio: Optional. True, if the bot can edit the bio of the business account.
+    :type can_edit_bio: bool, optional
+    :param can_edit_profile_photo: Optional. True, if the bot can edit the profile photo of the business account.
+    :type can_edit_profile_photo: bool, optional
+    :param can_edit_username: Optional. True, if the bot can edit the username of the business account.
+    :type can_edit_username: bool, optional
+    :param can_change_gift_settings: Optional. True, if the bot can change the privacy settings pertaining to gifts for the business account.
+    :type can_change_gift_settings: bool, optional
+    :param can_view_gifts_and_stars: Optional. True, if the bot can view gifts and the amount of Telegram Stars owned by the business account.
+    :type can_view_gifts_and_stars: bool, optional
+    :param can_convert_gifts_to_stars: Optional. True, if the bot can convert regular gifts owned by the business account to Telegram Stars.
+    :type can_convert_gifts_to_stars: bool, optional
+    :param can_transfer_and_upgrade_gifts: Optional. True, if the bot can transfer and upgrade gifts owned by the business account.
+    :type can_transfer_and_upgrade_gifts: bool, optional
+    :param can_transfer_stars: Optional. True, if the bot can transfer Telegram Stars received by the business account to its own account, or use them to upgrade and transfer gifts.
+    :type can_transfer_stars: bool, optional
+    :param can_manage_stories: Optional. True, if the bot can post, edit and delete stories on behalf of the business account.
+    :type can_manage_stories: bool, optional
+
+    :return: Instance of the class
+    :rtype: :class:`tgram.types.BusinessBotRights`
+    """
+
+    def __init__(
+        self,
+        can_reply: "bool" = None,
+        can_read_messages: "bool" = None,
+        can_delete_sent_messages: "bool" = None,
+        can_delete_all_messages: "bool" = None,
+        can_edit_name: "bool" = None,
+        can_edit_bio: "bool" = None,
+        can_edit_profile_photo: "bool" = None,
+        can_edit_username: "bool" = None,
+        can_change_gift_settings: "bool" = None,
+        can_view_gifts_and_stars: "bool" = None,
+        can_convert_gifts_to_stars: "bool" = None,
+        can_transfer_and_upgrade_gifts: "bool" = None,
+        can_transfer_stars: "bool" = None,
+        can_manage_stories: "bool" = None,
+        me: "tgram.TgBot" = None,
+        json: "dict" = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.can_reply = can_reply
+        self.can_read_messages = can_read_messages
+        self.can_delete_sent_messages = can_delete_sent_messages
+        self.can_delete_all_messages = can_delete_all_messages
+        self.can_edit_name = can_edit_name
+        self.can_edit_bio = can_edit_bio
+        self.can_edit_profile_photo = can_edit_profile_photo
+        self.can_edit_username = can_edit_username
+        self.can_change_gift_settings = can_change_gift_settings
+        self.can_view_gifts_and_stars = can_view_gifts_and_stars
+        self.can_convert_gifts_to_stars = can_convert_gifts_to_stars
+        self.can_transfer_and_upgrade_gifts = can_transfer_and_upgrade_gifts
+        self.can_transfer_stars = can_transfer_stars
+        self.can_manage_stories = can_manage_stories
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["tgram.types.BusinessBotRights"]:
+        return (
+            BusinessBotRights(
+                me=me,
+                json=d,
+                can_reply=d.get("can_reply"),
+                can_read_messages=d.get("can_read_messages"),
+                can_delete_sent_messages=d.get("can_delete_sent_messages"),
+                can_delete_all_messages=d.get("can_delete_all_messages"),
+                can_edit_name=d.get("can_edit_name"),
+                can_edit_bio=d.get("can_edit_bio"),
+                can_edit_profile_photo=d.get("can_edit_profile_photo"),
+                can_edit_username=d.get("can_edit_username"),
+                can_change_gift_settings=d.get("can_change_gift_settings"),
+                can_view_gifts_and_stars=d.get("can_view_gifts_and_stars"),
+                can_convert_gifts_to_stars=d.get("can_convert_gifts_to_stars"),
+                can_transfer_and_upgrade_gifts=d.get("can_transfer_and_upgrade_gifts"),
+                can_transfer_stars=d.get("can_transfer_stars"),
+                can_manage_stories=d.get("can_manage_stories"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )

--- a/tgram/types/_business_connection.py
+++ b/tgram/types/_business_connection.py
@@ -22,8 +22,8 @@ class BusinessConnection(Type_):
     :param date: Date the connection was established in Unix time
     :type date: :obj:`int`
 
-    :param can_reply: True, if the bot can act on behalf of the business account in chats that were active in the last 24 hours
-    :type can_reply: :obj:`bool`
+    :param rights: Optional. Rights of the business bot
+    :type rights: :class:`tgram.types.BusinessBotRights`
 
     :param is_enabled: True, if the connection is active
     :type is_enabled: :obj:`bool`
@@ -38,7 +38,7 @@ class BusinessConnection(Type_):
         user: "tgram.types.User" = None,
         user_chat_id: "int" = None,
         date: "int" = None,
-        can_reply: "bool" = None,
+        rights: "tgram.types.BusinessBotRights" = None,
         is_enabled: "bool" = None,
         me: "tgram.TgBot" = None,
         json: "dict" = None,
@@ -48,7 +48,7 @@ class BusinessConnection(Type_):
         self.user = user
         self.user_chat_id = user_chat_id
         self.date = date
-        self.can_reply = can_reply
+        self.rights = rights
         self.is_enabled = is_enabled
 
     @staticmethod
@@ -63,7 +63,7 @@ class BusinessConnection(Type_):
                 user=tgram.types.User._parse(me=me, d=d.get("user")),
                 user_chat_id=d.get("user_chat_id"),
                 date=d.get("date"),
-                can_reply=d.get("can_reply"),
+                rights=tgram.types.BusinessBotRights._parse(me=me, d=d.get("rights")),
                 is_enabled=d.get("is_enabled"),
             )
             if d and (force or me and __class__.__name__ not in me._custom_types)

--- a/tgram/types/_chat_full_info.py
+++ b/tgram/types/_chat_full_info.py
@@ -134,8 +134,8 @@ class ChatFullInfo(Type_, bound.ChatB):
     :param can_set_sticker_set: Optional. :obj:`bool`, if the bot can change the group sticker set. Returned only in getChat.
     :type can_set_sticker_set: :obj:`bool`
 
-    :param can_send_gift: Optional. :obj:`bool`, if gifts can be sent to the chat.
-    :type can_send_gift: :obj:`bool`
+    :param AcceptedGiftTypes: Information about types of gifts that are accepted by the chat or by the corresponding user for private chats.
+    :type AcceptedGiftTypes: :class:`tgram.types.AcceptedGiftTypes`
 
     :param can_send_paid_media: Optional. :obj:`bool`, if paid media messages can be sent or forwarded to the channel chat. The field is available only for channel chats.
     :type can_send_paid_media: :obj:`bool`
@@ -190,7 +190,7 @@ class ChatFullInfo(Type_, bound.ChatB):
         invite_link: "str" = None,
         pinned_message: "tgram.types.Message" = None,
         permissions: "tgram.types.ChatPermissions" = None,
-        can_send_gift: bool = None,
+        accepted_gift_types: "tgram.types.AcceptedGiftTypes" = None,
         can_send_paid_media: bool = None,
         slow_mode_delay: "int" = None,
         unrestrict_boost_count: "int" = None,
@@ -241,7 +241,7 @@ class ChatFullInfo(Type_, bound.ChatB):
         self.invite_link = invite_link
         self.pinned_message = pinned_message
         self.permissions = permissions
-        self.can_send_gift = can_send_gift
+        self.accepted_gift_types = accepted_gift_types
         self.can_send_paid_media = can_send_paid_media
         self.slow_mode_delay = slow_mode_delay
         self.unrestrict_boost_count = unrestrict_boost_count
@@ -311,7 +311,9 @@ class ChatFullInfo(Type_, bound.ChatB):
                 permissions=tgram.types.ChatPermissions._parse(
                     me=me, d=d.get("permissions")
                 ),
-                can_send_gift=d.get("can_send_gift"),
+                accepted_gift_types=tgram.types.AcceptedGiftTypes._parse(
+                    me=me, d=d.get("accepted_gift_types")
+                ),
                 can_send_paid_media=d.get("can_send_paid_media"),
                 slow_mode_delay=d.get("slow_mode_delay"),
                 unrestrict_boost_count=d.get("unrestrict_boost_count"),

--- a/tgram/types/_gift_info.py
+++ b/tgram/types/_gift_info.py
@@ -1,0 +1,79 @@
+import tgram
+
+from .type_ import Type_
+from typing import List, Optional
+
+
+class GiftInfo(Type_):
+    """
+    Describes a service message about a regular gift that was sent or received.
+
+    :param gift: Information about the gift
+    :type gift: :class:`tgram.types.Gift`
+    :param owned_gift_id: Optional. Unique identifier of the received gift for the bot; only present for gifts received on behalf of business accounts
+    :type owned_gift_id: :obj:`str`
+    :param convert_star_count: Optional. Number of Telegram Stars that can be claimed by the receiver by converting the gift; omitted if conversion to Telegram Stars is impossible
+    :type convert_star_count: :obj:`int`
+    :param prepaid_upgrade_star_count: Optional. Number of Telegram Stars that were prepaid by the sender for the ability to upgrade the gift
+    :type prepaid_upgrade_star_count: :obj:`int`
+    :param can_be_upgraded: Optional. True, if the gift can be upgraded to a unique gift
+    :type can_be_upgraded: :obj:`bool`
+    :param text: Optional. Text of the message that was added to the gift
+    :type text: :obj:`str`
+    :param entities: Optional. Special entities that appear in the text
+    :type entities: List[:class:`tgram.types.MessageEntity`]
+    :param is_private: Optional. True, if the sender and gift text are shown only to the gift receiver; otherwise, everyone will be able to see them
+    :type is_private: :obj:`bool`
+    """
+
+    def __init__(
+        self,
+        gift: "tgram.types.Gift" = None,
+        owned_gift_id: "str" = None,
+        convert_star_count: "int" = None,
+        prepaid_upgrade_star_count: "int" = None,
+        can_be_upgraded: "bool" = None,
+        text: "str" = None,
+        entities: List["tgram.types.MessageEntity"] = None,
+        is_private: "bool" = None,
+        me: "tgram.TgBot" = None,
+        json: "dict" = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.gift = gift
+        self.owned_gift_id = owned_gift_id
+        self.convert_star_count = convert_star_count
+        self.prepaid_upgrade_star_count = prepaid_upgrade_star_count
+        self.can_be_upgraded = can_be_upgraded
+        self.text = text
+        self.entities = entities
+        self.is_private = is_private
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["GiftInfo"]:
+        return (
+            GiftInfo(
+                gift=tgram.types.Gift._parse(me, d.get("gift")),
+                owned_gift_id=d.get("owned_gift_id"),
+                convert_star_count=d.get("convert_star_count"),
+                prepaid_upgrade_star_count=d.get("prepaid_upgrade_star_count"),
+                can_be_upgraded=d.get("can_be_upgraded"),
+                text=d.get("text"),
+                entities=[
+                    tgram.types.MessageEntity._parse(me, ent)
+                    for ent in d.get("entities", [])
+                ]
+                if d.get("entities")
+                else None,
+                is_private=d.get("is_private"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )

--- a/tgram/types/_input_profile_photo.py
+++ b/tgram/types/_input_profile_photo.py
@@ -1,0 +1,100 @@
+import tgram
+from .type_ import Type_
+
+from typing import Optional, Union
+from pathlib import Path
+
+
+class InputProfilePhotoStatic(Type_):
+    """
+    A static profile photo in the .JPG format.
+
+    Telegram Documentation: https://core.telegram.org/bots/api#inputprofilephotostatic
+
+    :param photo: The static profile photo. Profile photos can't be reused and can only be uploaded as a new file,
+        so you can pass “attach://<file_attach_name>” if the photo was uploaded using multipart/form-data under <file_attach_name>.
+        More information on Sending Files »
+    :type photo: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`tgram.types.InputProfilePhotoStatic`
+    """
+
+    def __init__(
+        self,
+        photo: Union["Path", "str"] = None,
+        me: "tgram.TgBot" = None,
+        json: "dict" = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.type = "static"
+        self.photo = photo
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["tgram.types.InputProfilePhotoStatic"]:
+        return (
+            InputProfilePhotoStatic(
+                me=me,
+                json=d,
+                photo=d.get("photo"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class InputProfilePhotoAnimated(Type_):
+    """
+    An animated profile photo in the MPEG4 format.
+
+    Telegram Documentation: https://core.telegram.org/bots/api#inputprofilephotoanimated
+
+    :param animation: The animated profile photo. Profile photos can't be reused and can only be uploaded as a new file,
+        so you can pass “attach://<file_attach_name>” if the photo was uploaded using multipart/form-data under <file_attach_name>.
+        More information on Sending Files »
+    :type animation: :obj:`str`
+    :param main_frame_timestamp: Optional. Timestamp in seconds of the frame that will be used as the static profile photo. Defaults to 0.0.
+    :type main_frame_timestamp: :obj:`float`, optional
+
+    :return: Instance of the class
+    :rtype: :class:`tgram.types.InputProfilePhotoAnimated`
+    """
+
+    def __init__(
+        self,
+        animation: Union["Path", "str"] = None,
+        main_frame_timestamp: Optional[float] = None,
+        me: "tgram.TgBot" = None,
+        json: "dict" = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.type = "animated"
+        self.animation = animation
+        self.main_frame_timestamp = main_frame_timestamp
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["tgram.types.InputProfilePhotoAnimated"]:
+        return (
+            InputProfilePhotoAnimated(
+                me=me,
+                json=d,
+                animation=d.get("animation"),
+                main_frame_timestamp=d.get("main_frame_timestamp"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )

--- a/tgram/types/_input_story_content.py
+++ b/tgram/types/_input_story_content.py
@@ -1,0 +1,94 @@
+import tgram
+from .type_ import Type_
+from typing import Optional
+
+
+class InputStoryContentPhoto(Type_):
+    """
+    Describes a photo to post as a story.
+
+    :param type: Type of the content, always "photo"
+    :type type: :obj:`str`
+    :param photo: The photo to post as a story. The photo must be of the size 1080x1920 and must not exceed 10 MB.
+    :type photo: :obj:`str`
+    """
+
+    def __init__(
+        self,
+        photo: str = None,
+        me: "tgram.TgBot" = None,
+        json: dict = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.type = "photo"
+        self.photo = photo
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["InputStoryContentPhoto"]:
+        return (
+            InputStoryContentPhoto(
+                photo=d.get("photo"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class InputStoryContentVideo(Type_):
+    """
+    Describes a video to post as a story.
+
+    :param type: Type of the content, always "video"
+    :type type: :obj:`str`
+    :param video: The video to post as a story. The video must be of the size 720x1280, streamable, encoded with H.265 codec, with key frames added each second in the MPEG4 format, and must not exceed 30 MB.
+    :type video: :obj:`str`
+    :param duration: Optional. Precise duration of the video in seconds; 0-60
+    :type duration: :obj:`float`
+    :param cover_frame_timestamp: Optional. Timestamp in seconds of the frame that will be used as the static cover for the story. Defaults to 0.0.
+    :type cover_frame_timestamp: :obj:`float`
+    :param is_animation: Optional. Pass True if the video has no sound
+    :type is_animation: :obj:`bool`
+    """
+
+    def __init__(
+        self,
+        video: str = None,
+        duration: float = None,
+        cover_frame_timestamp: float = None,
+        is_animation: bool = None,
+        me: "tgram.TgBot" = None,
+        json: dict = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.type = "video"
+        self.video = video
+        self.duration = duration
+        self.cover_frame_timestamp = cover_frame_timestamp
+        self.is_animation = is_animation
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["InputStoryContentVideo"]:
+        return (
+            InputStoryContentVideo(
+                video=d.get("video"),
+                duration=d.get("duration"),
+                cover_frame_timestamp=d.get("cover_frame_timestamp"),
+                is_animation=d.get("is_animation"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )

--- a/tgram/types/_location_address.py
+++ b/tgram/types/_location_address.py
@@ -1,0 +1,54 @@
+import tgram
+
+from .type_ import Type_
+from typing import Optional
+
+
+class LocationAddress(Type_):
+    """
+    Describes the physical address of a location.
+
+    :param country_code: The two-letter ISO 3166-1 alpha-2 country code of the country where the location is located
+    :type country_code: :obj:`str`
+    :param state: Optional. State of the location
+    :type state: :obj:`str`
+    :param city: Optional. City of the location
+    :type city: :obj:`str`
+    :param street: Optional. Street address of the location
+    :type street: :obj:`str`
+    """
+
+    def __init__(
+        self,
+        country_code: str = None,
+        state: str = None,
+        city: str = None,
+        street: str = None,
+        me: "tgram.TgBot" = None,
+        json: dict = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.country_code = country_code
+        self.state = state
+        self.city = city
+        self.street = street
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["LocationAddress"]:
+        return (
+            LocationAddress(
+                country_code=d.get("country_code"),
+                state=d.get("state"),
+                city=d.get("city"),
+                street=d.get("street"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )

--- a/tgram/types/_message.py
+++ b/tgram/types/_message.py
@@ -224,6 +224,12 @@ class Message(Type_, bound.MessageB):
     :param chat_shared: Optional. Service message: a chat was shared with the bot
     :type chat_shared: :class:`tgram.types.ChatShared`
 
+    :param gift: Optional. Service message: a regular gift was sent or received
+        :type gift: :class:`tgram.types.GiftInfo`
+
+    :param unique_gift: Optional. Service message: a unique gift was sent or received
+    :type unique_gift: :class:`tgram.types.UniqueGiftInfo`
+
     :param connected_website: Optional. The domain name of the website on which the user has logged in. More about
         Telegram Login »
     :type connected_website: :obj:`str`
@@ -362,6 +368,8 @@ class Message(Type_, bound.MessageB):
         refunded_payment: "tgram.types.RefundedPayment" = None,
         users_shared: "tgram.types.UsersShared" = None,
         chat_shared: "tgram.types.ChatShared" = None,
+        gift: "tgram.types.GiftInfo" = None,
+        unique_gift: "tgram.types.UniqueGiftInfo" = None,
         connected_website: "str" = None,
         write_access_allowed: "tgram.types.WriteAccessAllowed" = None,
         passport_data: "tgram.types.PassportData" = None,

--- a/tgram/types/_message.py
+++ b/tgram/types/_message.py
@@ -299,6 +299,9 @@ class Message(Type_, bound.MessageB):
     :param reply_markup: Optional. Inline keyboard attached to the message. login_url buttons are represented as ordinary url buttons.
     :type reply_markup: :class:`tgram.types.InlineKeyboardMarkup`
 
+    :param paid_message_price_changed: Optional. Service message: the price for paid messages has changed in the chat
+    :type paid_message_price_changed: :class:`tgram.types.PaidMessagePriceChanged`
+
     :return: Instance of the class
     :rtype: :class:`tgram.types.Message`
     """
@@ -386,6 +389,7 @@ class Message(Type_, bound.MessageB):
         giveaway: "tgram.types.Giveaway" = None,
         giveaway_winners: "tgram.types.GiveawayWinners" = None,
         giveaway_completed: "tgram.types.GiveawayCompleted" = None,
+        paid_message_price_changed: "tgram.types.PaidMessagePriceChanged" = None,
         video_chat_scheduled: "tgram.types.VideoChatScheduled" = None,
         video_chat_started: "tgram.types.VideoChatStarted" = None,
         video_chat_ended: "tgram.types.VideoChatEnded" = None,
@@ -459,6 +463,8 @@ class Message(Type_, bound.MessageB):
         self.refunded_payment = refunded_payment
         self.users_shared = users_shared
         self.chat_shared = chat_shared
+        self.gift = gift
+        self.unique_gift = unique_gift
         self.connected_website = connected_website
         self.write_access_allowed = write_access_allowed
         self.passport_data = passport_data
@@ -475,6 +481,7 @@ class Message(Type_, bound.MessageB):
         self.giveaway = giveaway
         self.giveaway_winners = giveaway_winners
         self.giveaway_completed = giveaway_completed
+        self.paid_message_price_changed = paid_message_price_changed
         self.video_chat_scheduled = video_chat_scheduled
         self.video_chat_started = video_chat_started
         self.video_chat_ended = video_chat_ended
@@ -601,6 +608,10 @@ class Message(Type_, bound.MessageB):
                 chat_shared=tgram.types.ChatShared._parse(
                     me=me, d=d.get("chat_shared")
                 ),
+                gift=tgram.types.GiftInfo._parse(me=me, d=d.get("gift")),
+                unique_gift=tgram.types.UniqueGiftInfo._parse(
+                    me=me, d=d.get("unique_gift")
+                ),
                 connected_website=d.get("connected_website"),
                 write_access_allowed=tgram.types.WriteAccessAllowed._parse(
                     me=me, d=d.get("write_access_allowed")
@@ -644,6 +655,9 @@ class Message(Type_, bound.MessageB):
                 ),
                 giveaway_completed=tgram.types.GiveawayCompleted._parse(
                     me=me, d=d.get("giveaway_completed")
+                ),
+                paid_message_price_changed=tgram.types.PaidMessagePriceChanged._parse(
+                    me=me, d=d.get("paid_message_price_changed")
                 ),
                 video_chat_scheduled=tgram.types.VideoChatScheduled._parse(
                     me=me, d=d.get("video_chat_scheduled")

--- a/tgram/types/_owned_gifts.py
+++ b/tgram/types/_owned_gifts.py
@@ -1,0 +1,221 @@
+import tgram
+from .type_ import Type_
+from typing import List, Optional, Union
+
+
+class OwnedGiftRegular(Type_):
+    """
+    Describes a regular gift owned by a user or a chat.
+
+    :param type: Type of the gift, always "regular"
+    :type type: :obj:`str`
+    :param gift: Information about the regular gift
+    :type gift: :class:`tgram.types.Gift`
+    :param owned_gift_id: Optional. Unique identifier of the gift for the bot; for gifts received on behalf of business accounts only
+    :type owned_gift_id: :obj:`str`
+    :param sender_user: Optional. Sender of the gift if it is a known user
+    :type sender_user: :class:`tgram.types.User`
+    :param send_date: Date the gift was sent in Unix time
+    :type send_date: :obj:`int`
+    :param text: Optional. Text of the message that was added to the gift
+    :type text: :obj:`str`
+    :param entities: Optional. Special entities that appear in the text
+    :type entities: List[:class:`tgram.types.MessageEntity`]
+    :param is_private: Optional. True, if the sender and gift text are shown only to the gift receiver
+    :type is_private: :obj:`bool`
+    :param is_saved: Optional. True, if the gift is displayed on the account's profile page
+    :type is_saved: :obj:`bool`
+    :param can_be_upgraded: Optional. True, if the gift can be upgraded to a unique gift
+    :type can_be_upgraded: :obj:`bool`
+    :param was_refunded: Optional. True, if the gift was refunded and isn't available anymore
+    :type was_refunded: :obj:`bool`
+    :param convert_star_count: Optional. Number of Telegram Stars that can be claimed by the receiver instead of the gift
+    :type convert_star_count: :obj:`int`
+    :param prepaid_upgrade_star_count: Optional. Number of Telegram Stars that were paid by the sender for the ability to upgrade the gift
+    :type prepaid_upgrade_star_count: :obj:`int`
+    """
+
+    def __init__(
+        self,
+        gift: "tgram.types.Gift" = None,
+        owned_gift_id: str = None,
+        sender_user: "tgram.types.User" = None,
+        send_date: int = None,
+        text: str = None,
+        entities: List["tgram.types.MessageEntity"] = None,
+        is_private: bool = None,
+        is_saved: bool = None,
+        can_be_upgraded: bool = None,
+        was_refunded: bool = None,
+        convert_star_count: int = None,
+        prepaid_upgrade_star_count: int = None,
+        me: "tgram.TgBot" = None,
+        json: dict = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.type = "regular"
+        self.gift = gift
+        self.owned_gift_id = owned_gift_id
+        self.sender_user = sender_user
+        self.send_date = send_date
+        self.text = text
+        self.entities = entities
+        self.is_private = is_private
+        self.is_saved = is_saved
+        self.can_be_upgraded = can_be_upgraded
+        self.was_refunded = was_refunded
+        self.convert_star_count = convert_star_count
+        self.prepaid_upgrade_star_count = prepaid_upgrade_star_count
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["OwnedGiftRegular"]:
+        return (
+            OwnedGiftRegular(
+                gift=tgram.types.Gift._parse(me, d.get("gift")),
+                owned_gift_id=d.get("owned_gift_id"),
+                sender_user=tgram.types.User._parse(me, d.get("sender_user")),
+                send_date=d.get("send_date"),
+                text=d.get("text"),
+                entities=[
+                    tgram.types.MessageEntity._parse(me, ent)
+                    for ent in d.get("entities")
+                ]
+                if d.get("entities")
+                else None,
+                is_private=d.get("is_private"),
+                is_saved=d.get("is_saved"),
+                can_be_upgraded=d.get("can_be_upgraded"),
+                was_refunded=d.get("was_refunded"),
+                convert_star_count=d.get("convert_star_count"),
+                prepaid_upgrade_star_count=d.get("prepaid_upgrade_star_count"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class OwnedGiftUnique(Type_):
+    """
+    Describes a unique gift received and owned by a user or a chat.
+
+    :param type: Type of the gift, always "unique"
+    :type type: :obj:`str`
+    :param gift: Information about the unique gift
+    :type gift: :class:`tgram.types.UniqueGift`
+    :param owned_gift_id: Optional. Unique identifier of the received gift for the bot; for gifts received on behalf of business accounts only
+    :type owned_gift_id: :obj:`str`
+    :param sender_user: Optional. Sender of the gift if it is a known user
+    :type sender_user: :class:`tgram.types.User`
+    :param send_date: Date the gift was sent in Unix time
+    :type send_date: :obj:`int`
+    :param is_saved: Optional. True, if the gift is displayed on the account's profile page
+    :type is_saved: :obj:`bool`
+    :param can_be_transferred: Optional. True, if the gift can be transferred to another owner
+    :type can_be_transferred: :obj:`bool`
+    :param transfer_star_count: Optional. Number of Telegram Stars that must be paid to transfer the gift
+    :type transfer_star_count: :obj:`int`
+    """
+
+    def __init__(
+        self,
+        gift: "tgram.types.UniqueGift" = None,
+        owned_gift_id: str = None,
+        sender_user: "tgram.types.User" = None,
+        send_date: int = None,
+        is_saved: bool = None,
+        can_be_transferred: bool = None,
+        transfer_star_count: int = None,
+        me: "tgram.TgBot" = None,
+        json: dict = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.type = "unique"
+        self.gift = gift
+        self.owned_gift_id = owned_gift_id
+        self.sender_user = sender_user
+        self.send_date = send_date
+        self.is_saved = is_saved
+        self.can_be_transferred = can_be_transferred
+        self.transfer_star_count = transfer_star_count
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["OwnedGiftUnique"]:
+        return (
+            OwnedGiftUnique(
+                gift=tgram.types.UniqueGift._parse(me, d.get("gift")),
+                owned_gift_id=d.get("owned_gift_id"),
+                sender_user=tgram.types.User._parse(me, d.get("sender_user")),
+                send_date=d.get("send_date"),
+                is_saved=d.get("is_saved"),
+                can_be_transferred=d.get("can_be_transferred"),
+                transfer_star_count=d.get("transfer_star_count"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class OwnedGifts(Type_):
+    """
+    Contains the list of gifts received and owned by a user or a chat.
+
+    :param total_count: The total number of gifts owned by the user or the chat
+    :type total_count: :obj:`int`
+    :param gifts: The list of gifts
+    :type gifts: List[Union[:class:`OwnedGiftRegular`, :class:`OwnedGiftUnique`]]
+    :param next_offset: Optional. Offset for the next request. If empty, then there are no more results
+    :type next_offset: :obj:`str`
+    """
+
+    def __init__(
+        self,
+        total_count: int = None,
+        gifts: List[Union["OwnedGiftRegular", "OwnedGiftUnique"]] = None,
+        next_offset: str = None,
+        me: "tgram.TgBot" = None,
+        json: dict = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.total_count = total_count
+        self.gifts = gifts
+        self.next_offset = next_offset
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["OwnedGifts"]:
+        return (
+            OwnedGifts(
+                total_count=d.get("total_count"),
+                gifts=[
+                    (
+                        OwnedGiftRegular._parse(me, g)
+                        if g.get("type") == "regular"
+                        else OwnedGiftUnique._parse(me, g)
+                    )
+                    for g in d.get("gifts")
+                ],
+                next_offset=d.get("next_offset"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )

--- a/tgram/types/_paid_message_price_changed.py
+++ b/tgram/types/_paid_message_price_changed.py
@@ -1,0 +1,44 @@
+import tgram
+from .type_ import Type_
+
+from typing import Optional
+
+
+class PaidMessagePriceChanged(Type_):
+    """
+    Describes a service message about a change in the price of paid messages within a chat.
+
+    :param paid_message_star_count: The new number of Telegram Stars that must be paid by non-administrator users of the supergroup chat for each sent message
+    :type paid_message_star_count: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`tgram.types.PaidMessagePriceChanged`
+    """
+
+    def __init__(
+        self,
+        paid_message_star_count: int = None,
+        me: "tgram.TgBot" = None,
+        json: "dict" = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.paid_message_star_count = paid_message_star_count
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["PaidMessagePriceChanged"]:
+        return (
+            PaidMessagePriceChanged(
+                me=me,
+                json=d,
+                paid_message_star_count=d.get("paid_message_star_count"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )

--- a/tgram/types/_star_amount.py
+++ b/tgram/types/_star_amount.py
@@ -1,0 +1,51 @@
+import tgram
+from .type_ import Type_
+from typing import Optional
+
+
+class StarAmount(Type_):
+    """
+    Describes an amount of Telegram Stars.
+
+    Telegram documentation: https://core.telegram.org/bots/api#staramount
+
+    :param amount: Integer amount of Telegram Stars, rounded to 0; can be negative
+    :type amount: :obj:`int`
+
+    :param nanostar_amount: Optional. The number of 1/1000000000 shares of Telegram Stars; from -999999999 to 999999999; can be negative if and only if amount is non-positive
+    :type nanostar_amount: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`StarAmount`
+    """
+
+    def __init__(
+        self,
+        amount: "int" = None,
+        nanostar_amount: "int" = None,
+        me: "tgram.TgBot" = None,
+        json: "dict" = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.amount = amount
+        self.nanostar_amount = nanostar_amount
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["StarAmount"]:
+        return (
+            StarAmount(
+                me=me,
+                json=d,
+                amount=d.get("amount"),
+                nanostar_amount=d.get("nanostar_amount"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )

--- a/tgram/types/_story_area.py
+++ b/tgram/types/_story_area.py
@@ -1,0 +1,339 @@
+import tgram
+from .type_ import Type_
+from typing import Optional
+
+
+class StoryAreaPosition(Type_):
+    """
+    Describes the position of a clickable area within a story.
+
+    :param x_percentage: The abscissa of the area's center, as a percentage of the media width
+    :type x_percentage: :obj:`float`
+    :param y_percentage: The ordinate of the area's center, as a percentage of the media height
+    :type y_percentage: :obj:`float`
+    :param width_percentage: The width of the area's rectangle, as a percentage of the media width
+    :type width_percentage: :obj:`float`
+    :param height_percentage: The height of the area's rectangle, as a percentage of the media height
+    :type height_percentage: :obj:`float`
+    :param rotation_angle: The clockwise rotation angle of the rectangle, in degrees; 0-360
+    :type rotation_angle: :obj:`float`
+    :param corner_radius_percentage: The radius of the rectangle corner rounding, as a percentage of the media width
+    :type corner_radius_percentage: :obj:`float`
+    """
+
+    def __init__(
+        self,
+        x_percentage: float = None,
+        y_percentage: float = None,
+        width_percentage: float = None,
+        height_percentage: float = None,
+        rotation_angle: float = None,
+        corner_radius_percentage: float = None,
+        me: "tgram.TgBot" = None,
+        json: dict = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.x_percentage = x_percentage
+        self.y_percentage = y_percentage
+        self.width_percentage = width_percentage
+        self.height_percentage = height_percentage
+        self.rotation_angle = rotation_angle
+        self.corner_radius_percentage = corner_radius_percentage
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["StoryAreaPosition"]:
+        return (
+            StoryAreaPosition(
+                x_percentage=d.get("x_percentage"),
+                y_percentage=d.get("y_percentage"),
+                width_percentage=d.get("width_percentage"),
+                height_percentage=d.get("height_percentage"),
+                rotation_angle=d.get("rotation_angle"),
+                corner_radius_percentage=d.get("corner_radius_percentage"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class StoryAreaTypeLocation(Type_):
+    """
+    Describes a story area pointing to a location.
+
+    :param type: Type of the area, always "location"
+    :type type: :obj:`str`
+    :param latitude: Location latitude in degrees
+    :type latitude: :obj:`float`
+    :param longitude: Location longitude in degrees
+    :type longitude: :obj:`float`
+    :param address: Optional. Address of the location
+    :type address: :obj:`LocationAddress`
+    """
+
+    def __init__(
+        self,
+        latitude: float = None,
+        longitude: float = None,
+        address: "tgram.types.LocationAddress" = None,
+        me: "tgram.TgBot" = None,
+        json: dict = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.type = "location"
+        self.latitude = latitude
+        self.longitude = longitude
+        self.address = address
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["StoryAreaTypeLocation"]:
+        return (
+            StoryAreaTypeLocation(
+                latitude=d.get("latitude"),
+                longitude=d.get("longitude"),
+                address=tgram.types.LocationAddress._parse(me=me, d=d.get("address"))
+                if d.get("address")
+                else None,
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class StoryAreaTypeSuggestedReaction(Type_):
+    """
+    Describes a story area pointing to a suggested reaction.
+
+    :param type: Type of the area, always "suggested_reaction"
+    :type type: :obj:`str`
+    :param reaction_type: Type of the reaction
+    :type reaction_type: :obj:`ReactionType`
+    :param is_dark: Optional. Pass True if the reaction area has a dark background
+    :type is_dark: :obj:`bool`
+    :param is_flipped: Optional. Pass True if reaction area corner is flipped
+    :type is_flipped: :obj:`bool`
+    """
+
+    def __init__(
+        self,
+        reaction_type: "tgram.types.ReactionType" = None,
+        is_dark: bool = None,
+        is_flipped: bool = None,
+        me: "tgram.TgBot" = None,
+        json: dict = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.type = "suggested_reaction"
+        self.reaction_type = reaction_type
+        self.is_dark = is_dark
+        self.is_flipped = is_flipped
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["StoryAreaTypeSuggestedReaction"]:
+        return (
+            StoryAreaTypeSuggestedReaction(
+                reaction_type=(
+                    tgram.types.ReactionTypeCustomEmoji._parse(
+                        me, d.get("reaction_type")
+                    )
+                    if d["reaction_type"]["type"] == "custom_emoji"
+                    else tgram.types.ReactionTypeEmoji._parse(
+                        me, d.get("reaction_type")
+                    )
+                    if d["reaction_type"]["type"] == "emoji"
+                    else tgram.types.ReactionTypePaid._parse(me, d.get("reaction_type"))
+                )
+                if d.get("reaction_type")
+                else None,
+                is_dark=d.get("is_dark"),
+                is_flipped=d.get("is_flipped"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class StoryAreaTypeLink(Type_):
+    """
+    Describes a story area pointing to an HTTP or tg:// link.
+
+    :param type: Type of the area, always "link"
+    :type type: :obj:`str`
+    :param url: HTTP or tg:// URL to be opened when the area is clicked
+    :type url: :obj:`str`
+    """
+
+    def __init__(
+        self,
+        url: str = None,
+        me: "tgram.TgBot" = None,
+        json: dict = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.type = "link"
+        self.url = url
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["StoryAreaTypeLink"]:
+        return (
+            StoryAreaTypeLink(
+                url=d.get("url"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class StoryAreaTypeWeather(Type_):
+    """
+    Describes a story area containing weather information.
+
+    :param type: Type of the area, always "weather"
+    :type type: :obj:`str`
+    :param temperature: Temperature, in degree Celsius
+    :type temperature: :obj:`float`
+    :param emoji: Emoji representing the weather
+    :type emoji: :obj:`str`
+    :param background_color: A color of the area background in the ARGB format
+    :type background_color: :obj:`int`
+    """
+
+    def __init__(
+        self,
+        temperature: float = None,
+        emoji: str = None,
+        background_color: int = None,
+        me: "tgram.TgBot" = None,
+        json: dict = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.type = "weather"
+        self.temperature = temperature
+        self.emoji = emoji
+        self.background_color = background_color
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["StoryAreaTypeWeather"]:
+        return (
+            StoryAreaTypeWeather(
+                temperature=d.get("temperature"),
+                emoji=d.get("emoji"),
+                background_color=d.get("background_color"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class StoryAreaTypeUniqueGift(Type_):
+    """
+    Describes a story area pointing to a unique gift.
+
+    :param type: Type of the area, always "unique_gift"
+    :type type: :obj:`str`
+    :param name: Unique name of the gift
+    :type name: :obj:`str`
+    """
+
+    def __init__(
+        self,
+        name: str = None,
+        me: "tgram.TgBot" = None,
+        json: dict = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.type = "unique_gift"
+        self.name = name
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["StoryAreaTypeUniqueGift"]:
+        return (
+            StoryAreaTypeUniqueGift(
+                name=d.get("name"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class StoryArea(Type_):
+    """
+    Describes a clickable area on a story media.
+
+    :param position: Position of the area
+    :type position: :obj:`StoryAreaPosition`
+    :param type: Type of the area
+    :type type: :obj:`StoryAreaType`
+    """
+
+    def __init__(
+        self,
+        position: StoryAreaPosition = None,
+        type: "tgram.types.StoryAreaType" = None,
+        me: "tgram.TgBot" = None,
+        json: dict = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.position = position
+        self.type = type
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["StoryArea"]:
+        return (
+            StoryArea(
+                position=StoryAreaPosition._parse(me=me, d=d.get("position"))
+                if d.get("position")
+                else None,
+                type=d.get("type"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )

--- a/tgram/types/_transaction_partner_user.py
+++ b/tgram/types/_transaction_partner_user.py
@@ -13,8 +13,32 @@ class TransactionPartnerUser(Type_):
     :param type: Type of the transaction partner, always “user”
     :type type: :obj:`str`
 
+    :param transaction_type: Type of the transaction, currently one of “invoice_payment”, “paid_media_payment”, “gift_purchase”, “premium_purchase”, “business_account_transfer”
+    :type transaction_type: :obj:`str`
+
     :param user: Information about the user
     :type user: :class:`User`
+
+    :param affiliate: Optional. Information about the affiliate that received a commission via this transaction. Can be available only for “invoice_payment” and “paid_media_payment” transactions.
+    :type affiliate: :class:`AffiliateInfo`, optional
+
+    :param invoice_payload: Optional. Bot-specified invoice payload. Can be available only for “invoice_payment” transactions.
+    :type invoice_payload: :obj:`str`, optional
+
+    :param subscription_period: Optional. The duration of the paid subscription. Can be available only for “invoice_payment” transactions.
+    :type subscription_period: :obj:`int`, optional
+
+    :param paid_media: Optional. Information about the paid media bought by the user; for “paid_media_payment” transactions only
+    :type paid_media: List[:class:`PaidMedia`], optional
+
+    :param paid_media_payload: Optional. Bot-specified paid media payload. Can be available only for “paid_media_payment” transactions.
+    :type paid_media_payload: :obj:`str`, optional
+
+    :param gift: Optional. The gift sent to the user by the bot; for “gift_purchase” transactions only
+    :type gift: :class:`Gift`, optional
+
+    :param premium_subscription_duration: Optional. Number of months the gifted Telegram Premium subscription will be active for; for “premium_purchase” transactions only
+    :type premium_subscription_duration: :obj:`int`, optional
 
     :return: Instance of the class
     :rtype: :class:`TransactionPartnerUser`
@@ -23,17 +47,20 @@ class TransactionPartnerUser(Type_):
     def __init__(
         self,
         user: "tgram.types.User" = None,
+        transaction_type: str = None,
         affiliate: "tgram.types.AffiliateInfo" = None,
-        invoice_payload: "str" = None,
-        subscription_period: "int" = None,
+        invoice_payload: str = None,
+        subscription_period: int = None,
         paid_media: List["tgram.types.PaidMedia"] = None,
-        paid_media_payload: "str" = None,
+        paid_media_payload: str = None,
         gift: "tgram.types.Gift" = None,
+        premium_subscription_duration: int = None,
         me: "tgram.TgBot" = None,
-        json: "dict" = None,
+        json: dict = None,
     ):
         super().__init__(me=me, json=json)
         self.type = "user"
+        self.transaction_type = transaction_type
         self.user = user
         self.affiliate = affiliate
         self.invoice_payload = invoice_payload
@@ -41,6 +68,7 @@ class TransactionPartnerUser(Type_):
         self.paid_media = paid_media
         self.paid_media_payload = paid_media_payload
         self.gift = gift
+        self.premium_subscription_duration = premium_subscription_duration
 
     @staticmethod
     def _parse(
@@ -50,8 +78,8 @@ class TransactionPartnerUser(Type_):
             TransactionPartnerUser(
                 me=me,
                 json=d,
-                type=d.get("type"),
                 user=tgram.types.User._parse(me=me, d=d.get("user")),
+                transaction_type=d.get("transaction_type"),
                 affiliate=tgram.types.AffiliateInfo._parse(me=me, d=d.get("affiliate")),
                 invoice_payload=d.get("invoice_payload"),
                 subscription_period=d.get("subscription_period"),
@@ -69,6 +97,7 @@ class TransactionPartnerUser(Type_):
                 else None,
                 paid_media_payload=d.get("paid_media_payload"),
                 gift=tgram.types.Gift._parse(me=me, d=d.get("gift")),
+                premium_subscription_duration=d.get("premium_subscription_duration"),
             )
             if d and (force or me and __class__.__name__ not in me._custom_types)
             else None

--- a/tgram/types/_unique_gifts.py
+++ b/tgram/types/_unique_gifts.py
@@ -1,0 +1,300 @@
+import tgram
+from .type_ import Type_
+from typing import Optional
+
+
+class UniqueGiftModel(Type_):
+    """
+    This object describes the model of a unique gift.
+
+    Telegram Documentation: https://core.telegram.org/bots/api#uniquegiftmodel
+
+    :param name: Name of the model
+    :type name: :obj:`str`
+    :param sticker: The sticker that represents the unique gift
+    :type sticker: :class:`tgram.types.Sticker`
+    :param rarity_per_mille: The number of unique gifts that receive this model for every 1000 gifts upgraded
+    :type rarity_per_mille: :obj:`int`
+    """
+
+    def __init__(
+        self,
+        name: "str" = None,
+        sticker: "tgram.types.Sticker" = None,
+        rarity_per_mille: "int" = None,
+        me: "tgram.TgBot" = None,
+        json: "dict" = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.name = name
+        self.sticker = sticker
+        self.rarity_per_mille = rarity_per_mille
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["UniqueGiftModel"]:
+        return (
+            UniqueGiftModel(
+                name=d.get("name"),
+                sticker=tgram.types.Sticker._parse(me, d.get("sticker")),
+                rarity_per_mille=d.get("rarity_per_mille"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class UniqueGiftSymbol(Type_):
+    """
+    This object describes the symbol shown on the pattern of a unique gift.
+
+    :param name: Name of the symbol
+    :type name: :obj:`str`
+    :param sticker: The sticker that represents the unique gift
+    :type sticker: :class:`tgram.types.Sticker`
+    :param rarity_per_mille: The number of unique gifts that receive this model for every 1000 gifts upgraded
+    :type rarity_per_mille: :obj:`int`
+    """
+
+    def __init__(
+        self,
+        name: "str" = None,
+        sticker: "tgram.types.Sticker" = None,
+        rarity_per_mille: "int" = None,
+        me: "tgram.TgBot" = None,
+        json: "dict" = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.name = name
+        self.sticker = sticker
+        self.rarity_per_mille = rarity_per_mille
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["UniqueGiftSymbol"]:
+        return (
+            UniqueGiftSymbol(
+                name=d.get("name"),
+                sticker=tgram.types.Sticker._parse(me, d.get("sticker")),
+                rarity_per_mille=d.get("rarity_per_mille"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class UniqueGiftBackdropColors(Type_):
+    """
+    This object describes the colors of the backdrop of a unique gift.
+
+    :param center_color: The color in the center of the backdrop in RGB format
+    :type center_color: :obj:`int`
+    :param edge_color: The color on the edges of the backdrop in RGB format
+    :type edge_color: :obj:`int`
+    :param symbol_color: The color to be applied to the symbol in RGB format
+    :type symbol_color: :obj:`int`
+    :param text_color: The color for the text on the backdrop in RGB format
+    :type text_color: :obj:`int`
+    """
+
+    def __init__(
+        self,
+        center_color: "int" = None,
+        edge_color: "int" = None,
+        symbol_color: "int" = None,
+        text_color: "int" = None,
+        me: "tgram.TgBot" = None,
+        json: "dict" = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.center_color = center_color
+        self.edge_color = edge_color
+        self.symbol_color = symbol_color
+        self.text_color = text_color
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["UniqueGiftBackdropColors"]:
+        return (
+            UniqueGiftBackdropColors(
+                center_color=d.get("center_color"),
+                edge_color=d.get("edge_color"),
+                symbol_color=d.get("symbol_color"),
+                text_color=d.get("text_color"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class UniqueGiftBackdrop(Type_):
+    """
+    This object describes the backdrop of a unique gift.
+
+    :param name: Name of the backdrop
+    :type name: :obj:`str`
+    :param colors: Colors of the backdrop
+    :type colors: :class:`tgram.types.UniqueGiftBackdropColors`
+    :param rarity_per_mille: The number of unique gifts that receive this backdrop for every 1000 gifts upgraded
+    :type rarity_per_mille: :obj:`int`
+    """
+
+    def __init__(
+        self,
+        name: "str" = None,
+        colors: "UniqueGiftBackdropColors" = None,
+        rarity_per_mille: "int" = None,
+        me: "tgram.TgBot" = None,
+        json: "dict" = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.name = name
+        self.colors = colors
+        self.rarity_per_mille = rarity_per_mille
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["UniqueGiftBackdrop"]:
+        return (
+            UniqueGiftBackdrop(
+                name=d.get("name"),
+                colors=UniqueGiftBackdropColors._parse(me, d.get("colors")),
+                rarity_per_mille=d.get("rarity_per_mille"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class UniqueGift(Type_):
+    """
+    This object describes a unique gift that was upgraded from a regular gift.
+
+    :param base_name: Human-readable name of the regular gift from which this unique gift was upgraded
+    :type base_name: :obj:`str`
+    :param name: Unique name of the gift. This name can be used in https://t.me/nft/... links and story areas
+    :type name: :obj:`str`
+    :param number: Unique number of the upgraded gift among gifts upgraded from the same regular gift
+    :type number: :obj:`int`
+    :param model: Model of the gift
+    :type model: :class:`tgram.types.UniqueGiftModel`
+    :param symbol: Symbol of the gift
+    :type symbol: :class:`tgram.types.UniqueGiftSymbol`
+    :param backdrop: Backdrop of the gift
+    :type backdrop: :class:`tgram.types.UniqueGiftBackdrop`
+    """
+
+    def __init__(
+        self,
+        base_name: "str" = None,
+        name: "str" = None,
+        number: "int" = None,
+        model: "UniqueGiftModel" = None,
+        symbol: "UniqueGiftSymbol" = None,
+        backdrop: "UniqueGiftBackdrop" = None,
+        me: "tgram.TgBot" = None,
+        json: "dict" = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.base_name = base_name
+        self.name = name
+        self.number = number
+        self.model = model
+        self.symbol = symbol
+        self.backdrop = backdrop
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["UniqueGift"]:
+        return (
+            UniqueGift(
+                base_name=d.get("base_name"),
+                name=d.get("name"),
+                number=d.get("number"),
+                model=UniqueGiftModel._parse(me, d.get("model")),
+                symbol=UniqueGiftSymbol._parse(me, d.get("symbol")),
+                backdrop=UniqueGiftBackdrop._parse(me, d.get("backdrop")),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )
+
+
+class UniqueGiftInfo(Type_):
+    """
+    Describes a service message about a unique gift that was sent or received.
+
+    :param gift: Information about the gift
+    :type gift: :class:`tgram.types.UniqueGift`
+    :param origin: Origin of the gift. Currently, either “upgrade” or “transfer”
+    :type origin: :obj:`str`
+    :param owned_gift_id: Optional. Unique identifier of the received gift for the bot; only present for gifts received on behalf of business accounts
+    :type owned_gift_id: :obj:`str`
+    :param transfer_star_count: Optional. Number of Telegram Stars that must be paid to transfer the gift; omitted if the bot cannot transfer the gift
+    :type transfer_star_count: :obj:`int`
+    """
+
+    def __init__(
+        self,
+        gift: "UniqueGift" = None,
+        origin: "str" = None,
+        owned_gift_id: "str" = None,
+        transfer_star_count: "int" = None,
+        me: "tgram.TgBot" = None,
+        json: "dict" = None,
+    ):
+        super().__init__(me=me, json=json)
+        self.gift = gift
+        self.origin = origin
+        self.owned_gift_id = owned_gift_id
+        self.transfer_star_count = transfer_star_count
+
+    @staticmethod
+    def _parse(
+        me: "tgram.TgBot" = None, d: dict = None, force: bool = None
+    ) -> Optional["UniqueGiftInfo"]:
+        return (
+            UniqueGiftInfo(
+                gift=UniqueGift._parse(me, d.get("gift")),
+                origin=d.get("origin"),
+                owned_gift_id=d.get("owned_gift_id"),
+                transfer_star_count=d.get("transfer_star_count"),
+            )
+            if d and (force or me and __class__.__name__ not in me._custom_types)
+            else None
+            if not d
+            else Type_._custom_parse(
+                __class__._parse(me=me, d=d, force=True),
+                me._custom_types.get(__class__.__name__),
+            )
+        )

--- a/tgram/types/type_.py
+++ b/tgram/types/type_.py
@@ -2,9 +2,18 @@ import tgram
 import logging
 from json import dumps
 from tgram.utils import Json
+from typing import TypedDict, Union
 
 # Initialize logger
 logger = logging.getLogger(__name__)
+
+
+class Response(TypedDict):
+    ok: bool
+    result: Union[dict, bool]
+    error_code: int
+    description: str
+    parameters: dict
 
 
 class Type_:

--- a/tgram/utils/mention.py
+++ b/tgram/utils/mention.py
@@ -20,5 +20,8 @@ class Mention:
         return HTML_MENTION.format(name=self.name, user_id=self.user_id)
 
     def __str__(self) -> str:
-        log.warning("Make sure to use Mention.markdown or Mention.html.")
+        log.warning(
+            "Calling Mention object returns only the name. "
+            "If you want a formatted mention, use the 'markdown' or 'html' properties instead."
+        )
         return self.name


### PR DESCRIPTION
## Bot API 9.0

### Business Accounts

- [x] Added the class [BusinessBotRights](https://core.telegram.org/bots/api#businessbotrights) and replaced the field can_reply with the field rights of the type [BusinessBotRights](https://core.telegram.org/bots/api#businessbotrights) in the class [BusinessConnection](https://core.telegram.org/bots/api#businessconnection).
- [x] Added the method [readBusinessMessage](https://core.telegram.org/bots/api#readbusinessmessage), allowing bots to mark incoming messages as read on behalf of a business account.
- [x] Added the method [deleteBusinessMessages](https://core.telegram.org/bots/api#deletebusinessmessages), allowing bots to delete messages on behalf of a business account.
- [x] Added the method [setBusinessAccountName](https://core.telegram.org/bots/api#setbusinessaccountname), allowing bots to change the first and last name of a managed business account.
- [x] Added the method [setBusinessAccountUsername](https://core.telegram.org/bots/api#setbusinessaccountusername), allowing bots to change the username of a managed business account.
- [x] Added the method [setBusinessAccountBio](https://core.telegram.org/bots/api#setbusinessaccountbio), allowing bots to change the bio of a managed business account.
- [x] Added the class [InputProfilePhoto](https://core.telegram.org/bots/api#inputprofilephoto), describing a profile photo to be set.
- [x] Added the methods [setBusinessAccountProfilePhoto](https://core.telegram.org/bots/api#setbusinessaccountprofilephoto) and [removeBusinessAccountProfilePhoto](https://core.telegram.org/bots/api#removebusinessaccountprofilephoto), allowing bots to change the profile photo of a managed business account.
- [x] Added the method [setBusinessAccountGiftSettings](https://core.telegram.org/bots/api#setbusinessaccountgiftsettings), allowing bots to change the privacy settings pertaining to incoming gifts in a managed business account.
- [x] Added the class [StarAmount](https://core.telegram.org/bots/api#staramount) and the method [getBusinessAccountStarBalance](https://core.telegram.org/bots/api#getbusinessaccountstarbalance), allowing bots to check the current Telegram Star balance of a managed business account.
- [x] Added the method [transferBusinessAccountStars](https://core.telegram.org/bots/api#transferbusinessaccountstars), allowing bots to transfer Telegram Stars from the balance of a managed business account to their own balance for withdrawal.
- [x] Added the classes [OwnedGiftRegular](https://core.telegram.org/bots/api#ownedgiftregular), [OwnedGiftUnique](https://core.telegram.org/bots/api#ownedgiftunique), [OwnedGifts](https://core.telegram.org/bots/api#ownedgifts) and the method [getBusinessAccountGifts](https://core.telegram.org/bots/api#getbusinessaccountgifts), allowing bots to fetch the list of gifts owned by a managed business account.
- [x] Added the method [convertGiftToStars](https://core.telegram.org/bots/api#convertgifttostars), allowing bots to convert gifts received by a managed business account to Telegram Stars.
- [x] Added the method [upgradeGift](https://core.telegram.org/bots/api#upgradegift), allowing bots to upgrade regular gifts received by a managed business account to unique gifts.
- [x] Added the method [transferGift](https://core.telegram.org/bots/api#transfergift), allowing bots to transfer unique gifts owned by a managed business account.
- [x] Added the classes [InputStoryContentPhoto](https://core.telegram.org/bots/api#inputstorycontentphoto) and [InputStoryContentVideo](https://core.telegram.org/bots/api#inputstorycontentvideo) representing the content of a story to post.
- [x] Added the classes [StoryArea](https://core.telegram.org/bots/api#storyarea), [StoryAreaPosition](https://core.telegram.org/bots/api#storyareaposition), [LocationAddress](https://core.telegram.org/bots/api#locationaddress), [StoryAreaTypeLocation](https://core.telegram.org/bots/api#storyareatypelocation), [StoryAreaTypeSuggestedReaction](https://core.telegram.org/bots/api#storyareatypesuggestedreaction), [StoryAreaTypeLink](https://core.telegram.org/bots/api#storyareatypelink), [StoryAreaTypeWeather](https://core.telegram.org/bots/api#storyareatypeweather) and [StoryAreaTypeUniqueGift](https://core.telegram.org/bots/api#storyareatypeuniquegift), describing clickable active areas on stories.
- [x] Added the method [postStory](https://core.telegram.org/bots/api#poststory), allowing bots to post a story on behalf of a managed business account.

- [x] Added the method [editStory](https://core.telegram.org/bots/api#editstory), allowing bots to edit stories they had previously posted on behalf of a managed business account.

- [x]  Added the method [deleteStory](https://core.telegram.org/bots/api#deletestory), allowing bots to delete stories they had previously posted on behalf of a managed business account.

### Gifts

- [x] Added the classes [UniqueGiftModel](https://core.telegram.org/bots/api#uniquegiftmodel), [UniqueGiftSymbol](https://core.telegram.org/bots/api#uniquegiftsymbol), [UniqueGiftBackdropColors](https://core.telegram.org/bots/api#uniquegiftbackdropcolors), and [UniqueGiftBackdrop](https://core.telegram.org/bots/api#uniquegiftbackdrop) to describe the properties of a unique gift.
- [x] Added the class [UniqueGift](https://core.telegram.org/bots/api#uniquegift) describing a gift that was upgraded to a unique one.
- [x] Added the class [AcceptedGiftTypes](https://core.telegram.org/bots/api#acceptedgifttypes) describing the types of gifts that are accepted by a user or a chat.
- [x] Replaced the field can_send_gift with the field accepted_gift_types of the type [AcceptedGiftTypes](https://core.telegram.org/bots/api#acceptedgifttypes) in the class [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo).
- [x] Added the class [GiftInfo](https://core.telegram.org/bots/api#giftinfo) and the field gift to the class [Message](https://core.telegram.org/bots/api#message), describing a service message about a regular gift that was sent or received.
- [x] Added the class [UniqueGiftInfo](https://core.telegram.org/bots/api#uniquegiftinfo) and the field unique_gift to the class [Message](https://core.telegram.org/bots/api#message), describing a service message about a unique gift that was sent or received.
## Bot API 9.0
### Telegram Premium

- [x] Added the method [giftPremiumSubscription](https://core.telegram.org/bots/api#giftpremiumsubscription), allowing bots to gift a user a Telegram Premium subscription paid in Telegram Stars.
- [x] Added the field premium_subscription_duration to the class [TransactionPartnerUser](https://core.telegram.org/bots/api#transactionpartneruser) for transactions involving a Telegram Premium subscription purchased by the bot.
- [x] Added the field transaction_type to the class [TransactionPartnerUser](https://core.telegram.org/bots/api#transactionpartneruser), simplifying the differentiation and processing of all transaction types.

### General

- [x] Increased the maximum price for paid media to 10000 Telegram Stars.
- [x] Increased the maximum price for a subscription period to 10000 Telegram Stars.
- [x] Added the class [PaidMessagePriceChanged](https://core.telegram.org/bots/api#paidmessagepricechanged) and the field paid_message_price_changed to the class [Message](https://core.telegram.org/bots/api#message), describing a service message about a price change for paid messages sent to the chat.
- [x] Added the field paid_star_count to the class [Message](https://core.telegram.org/bots/api#message), containing the number of [Telegram Stars](https://telegram.org/blog/telegram-stars) that were paid to send the message.